### PR TITLE
feat(database): add Flyway seed migrations for plans and system categories

### DIFF
--- a/src/main/resources/db/migration/V2__seed_plans.sql
+++ b/src/main/resources/db/migration/V2__seed_plans.sql
@@ -1,0 +1,37 @@
+INSERT INTO plans (
+    id,
+    code,
+    name,
+    price,
+    billing_period,
+    max_wallets,
+    max_budgets,
+    max_recurring_transactions,
+    max_shared_wallets,
+    max_wallet_members,
+    dashboard_customization,
+    can_create_shared_wallets,
+    export_enabled,
+    active,
+    created_at,
+    updated_at
+)
+VALUES (
+    gen_random_uuid(),
+    'FREE',
+    'Free Plan',
+    0,
+    'MONTHLY',
+    1,
+    3,
+    10,
+    0,
+    1,
+    false,
+    false,
+    false,
+    true,
+    NOW(),
+    NOW()
+)
+ON CONFLICT (code) DO NOTHING;

--- a/src/main/resources/db/migration/V3__seed_categories.sql
+++ b/src/main/resources/db/migration/V3__seed_categories.sql
@@ -1,0 +1,145 @@
+INSERT INTO categories (
+    id,
+    name,
+    type,
+    system_defined,
+    icon,
+    color,
+    created_at
+)
+VALUES
+(
+    gen_random_uuid(),
+    'Food',
+    'EXPENSE',
+    true,
+    'utensils',
+    '#EF4444',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Transportation',
+    'EXPENSE',
+    true,
+    'car',
+    '#3B82F6',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Housing',
+    'EXPENSE',
+    true,
+    'house',
+    '#10B981',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Utilities',
+    'EXPENSE',
+    true,
+    'bolt',
+    '#F59E0B',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Healthcare',
+    'EXPENSE',
+    true,
+    'heart-pulse',
+    '#EC4899',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Education',
+    'EXPENSE',
+    true,
+    'graduation-cap',
+    '#8B5CF6',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Entertainment',
+    'EXPENSE',
+    true,
+    'film',
+    '#6366F1',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Shopping',
+    'EXPENSE',
+    true,
+    'shopping-cart',
+    '#06B6D4',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Travel',
+    'EXPENSE',
+    true,
+    'plane',
+    '#14B8A6',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Other',
+    'EXPENSE',
+    true,
+    'circle-help',
+    '#6B7280',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Salary',
+    'INCOME',
+    true,
+    'briefcase',
+    '#22C55E',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Freelance',
+    'INCOME',
+    true,
+    'laptop',
+    '#0EA5E9',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Investment',
+    'INCOME',
+    true,
+    'trending-up',
+    '#A855F7',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Gift',
+    'INCOME',
+    true,
+    'gift',
+    '#F97316',
+    NOW()
+),
+(
+    gen_random_uuid(),
+    'Other',
+    'INCOME',
+    true,
+    'circle-help',
+    '#6B7280',
+    NOW()
+ON CONFLICT (name, type) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds initial Flyway seed migrations required for a fresh BFlow database.

### Changes

- Added `V2__seed_plans.sql`
  - Inserts the default `FREE` subscription plan.

- Added `V3__seed_system_categories.sql`
  - Inserts default system expense categories.
  - Inserts default system income categories.

### Why

These records are required by the application and should be provisioned automatically when a new database is initialized, ensuring consistent environments without requiring manual SQL scripts.

### Notes

- Seed data is idempotent using `ON CONFLICT`.
- Existing migrations were not modified.
- User-generated data is intentionally excluded from these migrations.