### PR TITLE
hotfix: remove invalid ON CONFLICT from category seed migration

### DIFF
--- a/src/main/resources/db/migration/V3__seed_categories.sql
+++ b/src/main/resources/db/migration/V3__seed_categories.sql
@@ -142,4 +142,4 @@ VALUES
     'circle-help',
     '#6B7280',
     NOW()
-ON CONFLICT (name, type) DO NOTHING;
+)


### PR DESCRIPTION
## Summary

This hotfix fixes the `V3__seed_categories.sql` Flyway migration by removing the invalid `ON CONFLICT` clause that caused migration failures during application startup.

## Changes

* Removed the `ON CONFLICT (name, type) DO NOTHING` clause from `V3__seed_categories.sql`.
* Kept the initial category seed unchanged.

## Reason

The `categories` table does not define a unique constraint on `(name, type)`, so PostgreSQL rejects the `ON CONFLICT` clause with:

> ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification

Since Flyway versioned migrations are executed only once, making this seed idempotent is unnecessary.

## Result

* Flyway migrations execute successfully.
* Application startup is no longer blocked.
* Initial system categories are seeded correctly.
