### PR TITLE
Dashboard endpoints for widgets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>bom</artifactId>
-				<version>2.49.5</version>
+				<version>2.51.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.3</version>
+			<version>3.1.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/bflow/auth/DTO/UserMeResponse.java
+++ b/src/main/java/bflow/auth/DTO/UserMeResponse.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 
 public record UserMeResponse(
         UUID id,
-        String email,
         List<String> roles,
         SubscriptionResponse subscription,
         List<WalletResponse> wallets,

--- a/src/main/java/bflow/auth/DTO/user/UserProfileResponse.java
+++ b/src/main/java/bflow/auth/DTO/user/UserProfileResponse.java
@@ -21,6 +21,12 @@ public class UserProfileResponse {
     /** The user's email address. */
     private String email;
 
+    /** The user's display name. */
+    private String name;
+
+    /** The URL of the user's profile picture. */
+    private String pictureUrl;
+
     /** The user's assigned roles. */
     private Set<String> roles;
 

--- a/src/main/java/bflow/auth/controllers/AuthController.java
+++ b/src/main/java/bflow/auth/controllers/AuthController.java
@@ -4,6 +4,7 @@ import bflow.auth.DTO.Record.SyncUserRequest;
 import bflow.auth.DTO.Record.SyncUserResponse;
 import bflow.auth.DTO.UserMeResponse;
 import bflow.auth.entities.User;
+import bflow.auth.mapper.UserMapper;
 import bflow.auth.services.AuthSyncService;
 import bflow.auth.services.CurrentUserService;
 import bflow.common.response.ApiResponse;
@@ -21,8 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -36,6 +35,9 @@ public class AuthController {
 
     /** Service used to resolve the authenticated user. */
     private final CurrentUserService currentUserService;
+
+    /** Mapper for building user-facing response DTOs. */
+    private final UserMapper userMapper;
 
     /**
      * Returns the current authenticated user's details.
@@ -53,14 +55,7 @@ public class AuthController {
         }
         User user = currentUserService.getCurrentUser(authentication);
 
-        UserMeResponse response = new UserMeResponse(
-                user.getId(),
-                user.getEmail(),
-                List.copyOf(user.getRoles()),
-                null,
-                List.of(),
-                null
-        );
+        UserMeResponse response = userMapper.toMeResponse(user);
 
         return ResponseEntity.ok(
                 ApiResponse.success(

--- a/src/main/java/bflow/auth/entities/User.java
+++ b/src/main/java/bflow/auth/entities/User.java
@@ -1,5 +1,6 @@
 package bflow.auth.entities;
 
+import bflow.auth.enums.PictureSource;
 import bflow.auth.enums.UserStatus;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -44,6 +45,20 @@ public class User {
     /** Unique email address of the user. */
     @Column(nullable = false, unique = true)
     private String email;
+
+    /** Display name of the user, captured from the Cognito ID token. */
+    @Column
+    private String name;
+
+    /** URL of the user's profile picture. */
+    @Column(name = "picture_url")
+    private String pictureUrl;
+
+    /** Origin of the current profile picture. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "picture_source", nullable = false)
+    @Builder.Default
+    private PictureSource pictureSource = PictureSource.NONE;
 
     /** The set of roles assigned to the user. */
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/java/bflow/auth/enums/PictureSource.java
+++ b/src/main/java/bflow/auth/enums/PictureSource.java
@@ -1,0 +1,14 @@
+package bflow.auth.enums;
+
+/**
+ * Origin of the user's profile picture. Determines whether the Cognito
+ * sync flow is allowed to overwrite it.
+ */
+public enum PictureSource {
+    /** Picture sourced from Google's OAuth profile claim. */
+    GOOGLE,
+    /** Picture manually uploaded by the user to S3. */
+    S3,
+    /** No picture set. */
+    NONE
+}

--- a/src/main/java/bflow/auth/mapper/UserMapper.java
+++ b/src/main/java/bflow/auth/mapper/UserMapper.java
@@ -1,0 +1,52 @@
+package bflow.auth.mapper;
+
+import bflow.auth.DTO.UserMeResponse;
+import bflow.auth.DTO.user.UserProfileResponse;
+import bflow.auth.entities.User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Maps User entities to their public-facing response DTOs.
+ */
+@Component
+public class UserMapper {
+
+    /**
+     * Builds the "/auth/me" response for the given user.
+     *
+     * <p>Subscription and wallets are intentionally left {@code null}/
+     * empty here — they are populated by their respective services once
+     * that wiring is in place, not by this mapper.
+     *
+     * @param user the authenticated user entity
+     * @return the assembled response DTO
+     */
+    public UserMeResponse toMeResponse(final User user) {
+        return new UserMeResponse(
+                user.getId(),
+                List.copyOf(user.getRoles()),
+                null,
+                List.of(),
+                toProfileResponse(user)
+        );
+    }
+
+    /**
+     * Maps a User entity to its public profile representation.
+     *
+     * @param user the user entity
+     * @return the mapped profile response
+     */
+    public UserProfileResponse toProfileResponse(final User user) {
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .pictureUrl(user.getPictureUrl())
+                .roles(user.getRoles())
+                .status(user.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/bflow/auth/mapper/package-info.java
+++ b/src/main/java/bflow/auth/mapper/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains mappers for authentication-related objects.
+ */
+package bflow.auth.mapper;

--- a/src/main/java/bflow/auth/services/AuthService.java
+++ b/src/main/java/bflow/auth/services/AuthService.java
@@ -2,10 +2,9 @@ package bflow.auth.services;
 
 import bflow.auth.DTO.UserMeResponse;
 import bflow.auth.entities.User;
-import bflow.auth.repository.RepositoryAuthAccount;
+import bflow.auth.mapper.UserMapper;
 import bflow.auth.repository.RepositoryUser;
 import bflow.common.exception.ResourceNotFoundException;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -21,10 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AuthService {
 
-    /** Repository for authentication account data. */
-    private final RepositoryAuthAccount authAccountRepository;
     /** Repository for core user profile data. */
     private final RepositoryUser userRepository;
+
+    /** Mapper for building user-facing response DTOs. */
+    private final UserMapper userMapper;
 
     /**
      * Finds a user by their unique identifier.
@@ -65,13 +65,6 @@ public class AuthService {
                                 "User not found"
                         ));
 
-        return new UserMeResponse(
-                user.getId(),
-                user.getEmail(),
-                List.copyOf(user.getRoles()),
-                null,
-                List.of(),
-                null
-        );
+        return userMapper.toMeResponse(user);
     }
 }

--- a/src/main/java/bflow/auth/services/AuthSyncService.java
+++ b/src/main/java/bflow/auth/services/AuthSyncService.java
@@ -3,6 +3,7 @@ package bflow.auth.services;
 import bflow.auth.DTO.Record.SyncUserRequest;
 import bflow.auth.DTO.Record.SyncUserResponse;
 import bflow.auth.entities.User;
+import bflow.auth.enums.PictureSource;
 import bflow.auth.enums.UserStatus;
 import bflow.auth.repository.RepositoryUser;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +54,8 @@ public class AuthSyncService {
         String sub = idToken.getSubject();
         String email = idToken.getClaimAsString("email");
         Boolean emailVerified = idToken.getClaimAsBoolean("email_verified");
+        String name = idToken.getClaimAsString("name");
+        String picture = idToken.getClaimAsString("picture");
 
         // Verify sub consistency between access token and id token
         if (!accessJwt.getSubject().equals(sub)) {
@@ -64,6 +67,8 @@ public class AuthSyncService {
         Optional<User> existingBySub = repositoryUser.findByCognitoSub(sub);
         if (existingBySub.isPresent()) {
             User user = existingBySub.get();
+            applyProfileClaims(user, name, picture);
+            repositoryUser.save(user);
             return new SyncUserResponse(
                     user.getId(),
                     user.getEmail(),
@@ -79,6 +84,7 @@ public class AuthSyncService {
             if (Boolean.TRUE.equals(emailVerified)) {
                 user.setEmailVerified(true);
             }
+            applyProfileClaims(user, name, picture);
             repositoryUser.save(user);
             return new SyncUserResponse(
                     user.getId(),
@@ -91,6 +97,10 @@ public class AuthSyncService {
         User newUser = User.builder()
                 .cognitoSub(sub)
                 .email(email)
+                .name(name)
+                .pictureUrl(picture)
+                .pictureSource(picture != null && !picture.isBlank()
+                        ? PictureSource.GOOGLE : PictureSource.NONE)
                 .status(UserStatus.ACTIVE)
                 .emailVerified(Boolean.TRUE.equals(emailVerified))
                 .roles(Set.of("ROLE_USER"))
@@ -105,5 +115,31 @@ public class AuthSyncService {
                 "ROLE_USER",
                 true
         );
+    }
+
+    /**
+     * Updates the user's name and, if the picture didn't come from an S3
+     * upload, their picture URL — sourced from the Cognito ID token.
+     *
+     * @param user the user to update
+     * @param name the display name claim, or {@code null}
+     * @param picture the picture URL claim, or {@code null}
+     */
+    private void applyProfileClaims(
+            final User user,
+            final String name,
+            final String picture
+    ) {
+        if (name != null && !name.isBlank()) {
+            user.setName(name);
+        }
+
+        boolean canOverwritePicture =
+                user.getPictureSource() != PictureSource.S3;
+
+        if (picture != null && !picture.isBlank() && canOverwritePicture) {
+            user.setPictureUrl(picture);
+            user.setPictureSource(PictureSource.GOOGLE);
+        }
     }
 }

--- a/src/main/java/bflow/budget/repository/RepositoryBudget.java
+++ b/src/main/java/bflow/budget/repository/RepositoryBudget.java
@@ -112,16 +112,54 @@ public interface RepositoryBudget extends JpaRepository<Budget, UUID>,
      */
     long countByUserId(UUID userId);
 
+    /**
+     * Checks whether a budget exists for the specified user, scope,
+     * category, and period.
+     *
+     * @param userId   the ID of the user
+     * @param scope    the budget scope
+     * @param categoryId the ID of the category
+     * @param period   the budget period
+     * @return true if a matching budget exists, otherwise false
+     */
     boolean existsByUserIdAndScopeAndCategoryIdAndPeriod(
             UUID userId, BudgetScope scope, UUID categoryId, PeriodType period
     );
 
+    /**
+     * Checks whether a budget exists for the specified user, scope,
+     * category, and period, excluding the budget with the specified ID.
+     *
+     * @param userId   the ID of the user
+     * @param scope    the budget scope
+     * @param categoryId the ID of the category
+     * @param period   the budget period
+     * @param id       the ID of the budget to exclude
+     * @return true if a matching budget exists, otherwise false
+     */
     boolean existsByUserIdAndScopeAndCategoryIdAndPeriodAndIdNot(
             UUID userId, BudgetScope scope, UUID categoryId,
             PeriodType period, UUID id
     );
 
+    /**
+     * Finds budgets for the specified user, scope, and category.
+     *
+     * @param userId     the ID of the user
+     * @param scope      the budget scope
+     * @param categoryId the ID of the category
+     * @return a list of matching budgets
+     */
     List<Budget> findByUserIdAndScopeAndCategoryId(
             UUID userId, BudgetScope scope, UUID categoryId
     );
+
+    /**
+     * Finds the 3 most recently updated budgets for a user — used for the
+     * "Budgets health" dashboard widget.
+     *
+     * @param userId the user ID
+     * @return up to 3 budgets ordered by most recently updated
+     */
+    List<Budget> findTop3ByUserIdOrderByUpdatedAtDesc(UUID userId);
 }

--- a/src/main/java/bflow/budget/repository/package-info.java
+++ b/src/main/java/bflow/budget/repository/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Repositories used to build queries for budgets.
+ */
+package bflow.budget.repository;

--- a/src/main/java/bflow/budget/services/BudgetCalculationService.java
+++ b/src/main/java/bflow/budget/services/BudgetCalculationService.java
@@ -37,6 +37,9 @@ public final class BudgetCalculationService {
      */
     private final BudgetLifecycleService lifecycleService;
 
+    /**
+     * Repository for managing wallet-user relationships.
+     */
     private final RepositoryWalletUser repositoryWalletUser;
 
     /**

--- a/src/main/java/bflow/budget/services/BudgetOverlapValidationService.java
+++ b/src/main/java/bflow/budget/services/BudgetOverlapValidationService.java
@@ -63,6 +63,7 @@ public final class BudgetOverlapValidationService {
      *
      * @param budget the budget entity being updated
      * @param scope the new budget scope
+     * @param walletId the wallet ID
      * @param categoryId the new category ID
      * @param period the new period type
      * @param userId the ID of the user (owner)

--- a/src/main/java/bflow/budget/services/BudgetService.java
+++ b/src/main/java/bflow/budget/services/BudgetService.java
@@ -198,7 +198,9 @@ public class BudgetService {
         );
 
         planLimitService.assertCanCreate(
-                userId, FeatureCodes.BUDGETS, repositoryBudget.countByUserId(userId)
+            userId,
+            FeatureCodes.BUDGETS,
+            repositoryBudget.countByUserId(userId)
         );
 
         Budget budget = new Budget();
@@ -208,11 +210,14 @@ public class BudgetService {
         budget.setThresholdCritical(request.getThresholdCritical());
         budget.setStartDate(request.getStartDate());
         budget.setScope(request.getScope());
+        budget.setLastAlertStatus(BudgetStatus.OK);
 
         if (request.getScope() != BudgetScope.CATEGORY_GLOBAL) {
             validateWalletAccess(request.getWalletId(), userId);
             budget.setWallet(
-                    entityManager.getReference(Wallet.class, request.getWalletId())
+                entityManager.getReference(
+                        Wallet.class, request.getWalletId()
+                )
             );
         }
 
@@ -706,7 +711,7 @@ public class BudgetService {
                             budget.getUser().getId()
                     );
             return repositoryExpense
-                .findByWalletIdInAndCategoryIdAndDateBetweenOrderByDateDescCreatedAtDesc(
+       .findByWalletIdInAndCategoryIdAndDateBetweenOrderByDateDescCreatedAtDesc(
                     walletIds,
                     budget.getCategory().getId(),
                     start,
@@ -720,14 +725,14 @@ public class BudgetService {
                         && budget.getCategory() != null;
 
         if (scopedToCategory) {
-            return repositoryExpense
-                    .findByWalletIdAndCategoryIdAndDateBetweenOrderByDateDescCreatedAtDesc(
-                            budget.getWallet().getId(),
-                            budget.getCategory().getId(),
-                            start,
-                            end,
-                            pageable
-                    );
+        return repositoryExpense
+        .findByWalletIdAndCategoryIdAndDateBetweenOrderByDateDescCreatedAtDesc(
+                        budget.getWallet().getId(),
+                        budget.getCategory().getId(),
+                        start,
+                        end,
+                        pageable
+                );
         }
 
         return repositoryExpense

--- a/src/main/java/bflow/budget/services/BudgetValidationService.java
+++ b/src/main/java/bflow/budget/services/BudgetValidationService.java
@@ -38,6 +38,7 @@ public final class BudgetValidationService {
      * Validate budget constraints including thresholds and scope.
      *
      * @param scope the budget scope
+     * @param walletId the wallet ID (required for WALLET scope)
      * @param categoryId the category ID (required for CATEGORY scope)
      * @param warning the warning threshold percentage
      * @param critical the critical threshold percentage

--- a/src/main/java/bflow/dashboard/controller/ControllerDashboard.java
+++ b/src/main/java/bflow/dashboard/controller/ControllerDashboard.java
@@ -1,0 +1,175 @@
+package bflow.dashboard.controller;
+
+import bflow.auth.services.CurrentUserService;
+import bflow.common.response.ApiResponse;
+import bflow.dashboard.dto.AveragesResponse;
+import bflow.dashboard.dto.BalanceSummaryResponse;
+import bflow.dashboard.dto.BudgetHealthItem;
+import bflow.dashboard.dto.RecentActivityItem;
+import bflow.dashboard.dto.SpendingSummaryResponse;
+import bflow.dashboard.dto.StatisticsResponse;
+import bflow.dashboard.service.ServiceDashboard;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Controller exposing per-widget endpoints for the main dashboard.
+ */
+@RestController
+@RequestMapping("/api/v1/dashboard")
+@RequiredArgsConstructor
+public final class ControllerDashboard {
+
+    /** Service handling dashboard aggregation logic. */
+    private final ServiceDashboard serviceDashboard;
+
+    /** Service used to resolve the authenticated user. */
+    private final CurrentUserService currentUserService;
+
+    /**
+     * Retrieves the "Balance total" widget data.
+     *
+     * @param authentication authenticated user.
+     * @param request current HTTP request.
+     * @return the balance summary.
+     */
+    @GetMapping("/balance")
+    public ApiResponse<BalanceSummaryResponse> getBalance(
+            final Authentication authentication,
+            final HttpServletRequest request
+    ) {
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+        BalanceSummaryResponse balance = serviceDashboard
+                .getBalanceSummary(userId);
+
+        return ApiResponse.success(
+                "Balance summary retrieved successfully",
+                balance,
+                request.getRequestURI()
+        );
+    }
+
+    /**
+     * Retrieves the "Statistics" widget data (income vs expenses, Jan-Dec).
+     *
+     * @param year optional target year; defaults to the current year.
+     * @param authentication authenticated user.
+     * @param request current HTTP request.
+     * @return the monthly statistics series.
+     */
+    @GetMapping("/statistics")
+    public ApiResponse<StatisticsResponse> getStatistics(
+            @RequestParam(required = false) final Integer year,
+            final Authentication authentication,
+            final HttpServletRequest request
+    ) {
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+        StatisticsResponse statistics = serviceDashboard
+                .getStatistics(userId, year);
+
+        return ApiResponse.success(
+                "Statistics retrieved successfully",
+                statistics,
+                request.getRequestURI()
+        );
+    }
+
+    /**
+     * Retrieves the "Average income" / "Average expenses" widget data.
+     *
+     * @param authentication authenticated user.
+     * @param request current HTTP request.
+     * @return the average's response.
+     */
+    @GetMapping("/averages")
+    public ApiResponse<AveragesResponse> getAverages(
+            final Authentication authentication,
+            final HttpServletRequest request
+    ) {
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+        AveragesResponse averages = serviceDashboard.getAverages(userId);
+
+        return ApiResponse.success(
+                "Averages retrieved successfully",
+                averages,
+                request.getRequestURI()
+        );
+    }
+
+    /**
+     * Retrieves the "Recent activity" widget data (top 5 transactions).
+     *
+     * @param authentication authenticated user.
+     * @param request current HTTP request.
+     * @return up to 5 recent activity items.
+     */
+    @GetMapping("/recent-activity")
+    public ApiResponse<List<RecentActivityItem>> getRecentActivity(
+            final Authentication authentication,
+            final HttpServletRequest request
+    ) {
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+        List<RecentActivityItem> activity = serviceDashboard
+                .getRecentActivity(userId);
+
+        return ApiResponse.success(
+                "Recent activity retrieved successfully",
+                activity,
+                request.getRequestURI()
+        );
+    }
+
+    /**
+     * Retrieves the "Spending this month" widget data.
+     *
+     * @param authentication authenticated user.
+     * @param request current HTTP request.
+     * @return the spending summary.
+     */
+    @GetMapping("/spending")
+    public ApiResponse<SpendingSummaryResponse> getSpending(
+            final Authentication authentication,
+            final HttpServletRequest request
+    ) {
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+        SpendingSummaryResponse spending = serviceDashboard
+                .getSpendingSummary(userId);
+
+        return ApiResponse.success(
+                "Spending summary retrieved successfully",
+                spending,
+                request.getRequestURI()
+        );
+    }
+
+    /**
+     * Retrieves the "Budgets health" widget data (top 3 budgets).
+     *
+     * @param authentication authenticated user.
+     * @param request current HTTP request.
+     * @return up to 3 budget health items.
+     */
+    @GetMapping("/budgets-health")
+    public ApiResponse<List<BudgetHealthItem>> getBudgetsHealth(
+            final Authentication authentication,
+            final HttpServletRequest request
+    ) {
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+        List<BudgetHealthItem> health = serviceDashboard
+                .getBudgetsHealth(userId);
+
+        return ApiResponse.success(
+                "Budgets health retrieved successfully",
+                health,
+                request.getRequestURI()
+        );
+    }
+}

--- a/src/main/java/bflow/dashboard/controller/package-info.java
+++ b/src/main/java/bflow/dashboard/controller/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains controllers for dashboard operations.
+ */
+package bflow.dashboard.controller;

--- a/src/main/java/bflow/dashboard/dto/AveragesResponse.java
+++ b/src/main/java/bflow/dashboard/dto/AveragesResponse.java
@@ -1,0 +1,10 @@
+package bflow.dashboard.dto;
+
+import java.math.BigDecimal;
+
+public record AveragesResponse(
+        BigDecimal averageIncome,
+        Double incomePercentageChangeLastMonth,
+        BigDecimal averageExpenses,
+        Double expensesPercentageChangeLastMonth
+) { }

--- a/src/main/java/bflow/dashboard/dto/BalanceSummaryResponse.java
+++ b/src/main/java/bflow/dashboard/dto/BalanceSummaryResponse.java
@@ -1,0 +1,8 @@
+package bflow.dashboard.dto;
+
+import java.math.BigDecimal;
+
+public record BalanceSummaryResponse(
+        BigDecimal total,
+        Double percentageChangeLastMonth
+) { }

--- a/src/main/java/bflow/dashboard/dto/BudgetHealthItem.java
+++ b/src/main/java/bflow/dashboard/dto/BudgetHealthItem.java
@@ -1,0 +1,13 @@
+package bflow.dashboard.dto;
+
+import bflow.budget.enums.BudgetStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record BudgetHealthItem(
+        UUID id,
+        String displayName,
+        Instant updatedAt,
+        BudgetStatus status
+) { }

--- a/src/main/java/bflow/dashboard/dto/CategoryPercentage.java
+++ b/src/main/java/bflow/dashboard/dto/CategoryPercentage.java
@@ -1,0 +1,9 @@
+package bflow.dashboard.dto;
+
+import java.util.UUID;
+
+public record CategoryPercentage(
+        UUID categoryId,
+        String categoryName,
+        Double percentage
+) { }

--- a/src/main/java/bflow/dashboard/dto/MonthlyPoint.java
+++ b/src/main/java/bflow/dashboard/dto/MonthlyPoint.java
@@ -1,0 +1,9 @@
+package bflow.dashboard.dto;
+
+import java.math.BigDecimal;
+
+public record MonthlyPoint(
+        String month,
+        BigDecimal income,
+        BigDecimal expense
+) { }

--- a/src/main/java/bflow/dashboard/dto/RecentActivityItem.java
+++ b/src/main/java/bflow/dashboard/dto/RecentActivityItem.java
@@ -1,0 +1,22 @@
+package bflow.dashboard.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * A single item in the "recent activity" feed.
+ *
+ * @param type the type of activity, such as income or expense
+ * @param name the name of the activity
+ * @param createdAt the date and time when the activity was created
+ * @param amount the activity amount,
+ * negative for expenses and positive for incomes
+ * @param walletName the name of the wallet associated with the activity
+ */
+public record RecentActivityItem(
+        String type,
+        String name,
+        Instant createdAt,
+        BigDecimal amount,
+        String walletName
+) { }

--- a/src/main/java/bflow/dashboard/dto/SpendingSummaryResponse.java
+++ b/src/main/java/bflow/dashboard/dto/SpendingSummaryResponse.java
@@ -1,0 +1,10 @@
+package bflow.dashboard.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record SpendingSummaryResponse(
+        BigDecimal totalSpent,
+        Double totalActivityPercentage,
+        List<CategoryPercentage> topCategories
+) { }

--- a/src/main/java/bflow/dashboard/dto/StatisticsResponse.java
+++ b/src/main/java/bflow/dashboard/dto/StatisticsResponse.java
@@ -1,0 +1,7 @@
+package bflow.dashboard.dto;
+
+import java.util.List;
+
+public record StatisticsResponse(
+        List<MonthlyPoint> months
+) { }

--- a/src/main/java/bflow/dashboard/dto/package-info.java
+++ b/src/main/java/bflow/dashboard/dto/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains data transfer objects used by the dashboard module.
+ */
+package bflow.dashboard.dto;

--- a/src/main/java/bflow/dashboard/projection/CategorySpendingProjection.java
+++ b/src/main/java/bflow/dashboard/projection/CategorySpendingProjection.java
@@ -1,0 +1,31 @@
+package bflow.dashboard.projection;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Projection containing aggregated spending information by category.
+ */
+public interface CategorySpendingProjection {
+
+    /**
+     * Returns the category identifier.
+     *
+     * @return the category identifier
+     */
+    UUID getCategoryId();
+
+    /**
+     * Returns the category name.
+     *
+     * @return the category name
+     */
+    String getCategoryName();
+
+    /**
+     * Returns the total spending for the category.
+     *
+     * @return the total spending
+     */
+    BigDecimal getTotal();
+}

--- a/src/main/java/bflow/dashboard/projection/MonthlyTotalProjection.java
+++ b/src/main/java/bflow/dashboard/projection/MonthlyTotalProjection.java
@@ -1,0 +1,23 @@
+package bflow.dashboard.projection;
+
+import java.math.BigDecimal;
+
+/**
+ * Projection for month-grouped sum queries (income/expense statistics).
+ */
+public interface MonthlyTotalProjection {
+
+    /**
+     * The calendar month number (1-12) for this aggregation row.
+     *
+     * @return the month number
+     */
+    Number getMonth();
+
+    /**
+     * The summed amount for this month.
+     *
+     * @return the total amount
+     */
+    BigDecimal getTotal();
+}

--- a/src/main/java/bflow/dashboard/projection/package-info.java
+++ b/src/main/java/bflow/dashboard/projection/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains projection interfaces used by the dashboard module.
+ */
+package bflow.dashboard.projection;

--- a/src/main/java/bflow/dashboard/service/ServiceDashboard.java
+++ b/src/main/java/bflow/dashboard/service/ServiceDashboard.java
@@ -1,0 +1,426 @@
+package bflow.dashboard.service;
+
+import bflow.auth.services.UserServiceImpl;
+import bflow.budget.entity.Budget;
+import bflow.budget.repository.RepositoryBudget;
+import bflow.dashboard.dto.AveragesResponse;
+import bflow.dashboard.dto.BalanceSummaryResponse;
+import bflow.dashboard.dto.BudgetHealthItem;
+import bflow.dashboard.dto.CategoryPercentage;
+import bflow.dashboard.dto.MonthlyPoint;
+import bflow.dashboard.dto.RecentActivityItem;
+import bflow.dashboard.dto.SpendingSummaryResponse;
+import bflow.dashboard.dto.StatisticsResponse;
+import bflow.dashboard.projection.CategorySpendingProjection;
+import bflow.dashboard.projection.MonthlyTotalProjection;
+import bflow.expenses.RepositoryExpense;
+import bflow.expenses.entity.Expense;
+import bflow.income.RepositoryIncome;
+import bflow.income.entity.Income;
+import bflow.wallet.repository.RepositoryWallet;
+import bflow.wallet.repository.RepositoryWalletUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Aggregates data from wallet, expense and income repositories to build
+ * the widgets shown on the user's main dashboard.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ServiceDashboard {
+
+    /** Number of items shown in the recent activity widget. */
+    private static final int RECENT_ACTIVITY_LIMIT = 5;
+
+    /** Number of top categories shown in the spending widget. */
+    private static final int TOP_CATEGORIES_LIMIT = 3;
+
+    /** Scale used for percentage calculations before rounding. */
+    private static final int PERCENTAGE_SCALE = 4;
+
+    /** Final rounding scale for percentages returned to the client. */
+    private static final int PERCENTAGE_DISPLAY_SCALE = 1;
+
+    /** Multiplier used to convert a ratio into a percentage. */
+    private static final BigDecimal PERCENTAGE_MULTIPLIER =
+            BigDecimal.valueOf(100);
+
+    /** Percentage value returned when a metric grows from a zero base. */
+    private static final double NEW_ACTIVITY_PERCENTAGE = 100.0;
+
+    /** First calendar month. */
+    private static final int JANUARY = 1;
+
+    /** Last calendar month. */
+    private static final int DECEMBER = 12;
+
+    /** Last day of December, used to build a full-year date range. */
+    private static final int DECEMBER_LAST_DAY = 31;
+
+    /** Repository for wallet-user membership queries. */
+    private final RepositoryWalletUser repositoryWalletUser;
+
+    /** Repository for wallet balance queries. */
+    private final RepositoryWallet repositoryWallet;
+
+    /** Repository for expense aggregation queries. */
+    private final RepositoryExpense repositoryExpense;
+
+    /** Repository for income aggregation queries. */
+    private final RepositoryIncome repositoryIncome;
+
+    /** Repository for budget health queries. */
+    private final RepositoryBudget repositoryBudget;
+
+    /** Service for user account validation. */
+    private final UserServiceImpl userService;
+
+    /**
+     * Builds the "Balance total" widget: current balance across every
+     * wallet the user belongs to, plus percentage change vs the balance
+     * at the start of the current month.
+     *
+     * Assumes balance only moves via income/expense at the aggregate
+     * level (transfers between the user's own wallets cancel out when
+     * summed together).
+     *
+     * @param userId the authenticated user's ID.
+     * @return the balance summary.
+     */
+    public BalanceSummaryResponse getBalanceSummary(final UUID userId) {
+        userService.validateUserActive(userId);
+        List<UUID> walletIds = repositoryWalletUser
+                .findWalletIdsByUserId(userId);
+
+        if (walletIds.isEmpty()) {
+            return new BalanceSummaryResponse(BigDecimal.ZERO, 0.0);
+        }
+
+        BigDecimal currentBalance = repositoryWallet
+                .sumBalanceByWalletIds(walletIds);
+
+        LocalDate today = LocalDate.now();
+        LocalDate startOfMonth = today.withDayOfMonth(1);
+
+        BigDecimal incomeThisMonth = repositoryIncome
+                .sumByWalletsAndDateRange(walletIds, startOfMonth, today);
+        BigDecimal expenseThisMonth = repositoryExpense
+                .sumByWalletsAndDateRange(walletIds, startOfMonth, today);
+
+        BigDecimal balanceStartOfMonth = currentBalance
+                .subtract(incomeThisMonth)
+                .add(expenseThisMonth);
+
+        Double percentageChange = calculatePercentageChange(
+                balanceStartOfMonth, currentBalance
+        );
+
+        return new BalanceSummaryResponse(currentBalance, percentageChange);
+    }
+
+    /**
+     * Builds the "Statistics" widget: total income vs total expenses per
+     * month for the given year (defaults to the current year).
+     *
+     * @param userId the authenticated user's ID.
+     * @param year the target year, or {@code null} for the current year.
+     * @return the monthly income/expense series, Jan through Dec.
+     */
+    public StatisticsResponse getStatistics(
+            final UUID userId, final Integer year
+    ) {
+        userService.validateUserActive(userId);
+        List<UUID> walletIds = repositoryWalletUser
+                .findWalletIdsByUserId(userId);
+
+        int targetYear = year != null ? year : LocalDate.now().getYear();
+        LocalDate start = LocalDate.of(targetYear, JANUARY, 1);
+        LocalDate end = LocalDate.of(targetYear, DECEMBER, DECEMBER_LAST_DAY);
+
+        Map<Integer, BigDecimal> incomeByMonth = walletIds.isEmpty()
+                ? Map.of()
+                : toMonthMap(repositoryIncome
+                .sumGroupedByMonth(walletIds, start, end));
+
+        Map<Integer, BigDecimal> expenseByMonth = walletIds.isEmpty()
+                ? Map.of()
+                : toMonthMap(repositoryExpense
+                .sumGroupedByMonth(walletIds, start, end));
+
+        List<MonthlyPoint> points = new ArrayList<>();
+        for (int month = JANUARY; month <= DECEMBER; month++) {
+            points.add(new MonthlyPoint(
+                    Month.of(month)
+                            .getDisplayName(TextStyle.SHORT, new Locale("es")),
+                    incomeByMonth.getOrDefault(month, BigDecimal.ZERO),
+                    expenseByMonth.getOrDefault(month, BigDecimal.ZERO)
+            ));
+        }
+
+        return new StatisticsResponse(points);
+    }
+
+    /**
+     * Builds the "Average income" / "Average expenses" widget.
+     *
+     * Average = year-to-date total divided by months elapsed.
+     * Percentage change compares this month's total against last month's
+     * total (matches the "% compared to last month" label in the UI).
+     *
+     * @param userId the authenticated user's ID.
+     * @return the averages response.
+     */
+    public AveragesResponse getAverages(final UUID userId) {
+        userService.validateUserActive(userId);
+        List<UUID> walletIds = repositoryWalletUser
+                .findWalletIdsByUserId(userId);
+
+        if (walletIds.isEmpty()) {
+            return new AveragesResponse(
+                    BigDecimal.ZERO, 0.0, BigDecimal.ZERO, 0.0
+            );
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate startOfThisMonth = today.withDayOfMonth(1);
+        LocalDate endOfLastMonth = startOfThisMonth.minusDays(1);
+        LocalDate startOfLastMonth = endOfLastMonth.withDayOfMonth(1);
+        LocalDate startOfYear = LocalDate.of(today.getYear(), JANUARY, 1);
+
+        BigDecimal incomeThisMonth = repositoryIncome
+                .sumByWalletsAndDateRange(walletIds, startOfThisMonth, today);
+        BigDecimal incomeLastMonth = repositoryIncome.sumByWalletsAndDateRange(
+                walletIds, startOfLastMonth, endOfLastMonth);
+
+        BigDecimal expenseThisMonth = repositoryExpense
+                .sumByWalletsAndDateRange(walletIds, startOfThisMonth, today);
+        BigDecimal expenseLastMonth = repositoryExpense
+                .sumByWalletsAndDateRange(
+                        walletIds, startOfLastMonth, endOfLastMonth
+                );
+
+        BigDecimal totalIncomeYtd = repositoryIncome
+                .sumByWalletsAndDateRange(walletIds, startOfYear, today);
+        BigDecimal totalExpenseYtd = repositoryExpense
+                .sumByWalletsAndDateRange(walletIds, startOfYear, today);
+
+        int monthsElapsed = today.getMonthValue();
+
+        BigDecimal avgIncome = totalIncomeYtd.divide(
+                BigDecimal.valueOf(monthsElapsed), 2, RoundingMode.HALF_EVEN);
+        BigDecimal avgExpense = totalExpenseYtd.divide(
+                BigDecimal.valueOf(monthsElapsed), 2, RoundingMode.HALF_EVEN);
+
+        return new AveragesResponse(
+                avgIncome,
+                calculatePercentageChange(incomeLastMonth, incomeThisMonth),
+                avgExpense,
+                calculatePercentageChange(expenseLastMonth, expenseThisMonth)
+        );
+    }
+
+    /**
+     * Builds the "Recent activity" widget: the 5 most recent transactions
+     * (expenses and incomes combined) across every wallet the user
+     * belongs to.
+     *
+     * @param userId the authenticated user's ID.
+     * @return up to 5 recent activity items, most recent first.
+     */
+    public List<RecentActivityItem> getRecentActivity(final UUID userId) {
+        userService.validateUserActive(userId);
+        List<UUID> walletIds = repositoryWalletUser
+                .findWalletIdsByUserId(userId);
+
+        if (walletIds.isEmpty()) {
+            return List.of();
+        }
+
+        Pageable limit = PageRequest.of(0, RECENT_ACTIVITY_LIMIT);
+
+        List<Expense> recentExpenses = repositoryExpense
+                .findByWalletIdInOrderByCreatedAtDesc(walletIds, limit);
+        List<Income> recentIncomes = repositoryIncome
+                .findByWalletIdInOrderByCreatedAtDesc(walletIds, limit);
+
+        return Stream.concat(
+                        recentExpenses.stream().map(this::toActivityItem),
+                        recentIncomes.stream().map(this::toActivityItem)
+                )
+                .sorted(Comparator.comparing(
+                        RecentActivityItem::createdAt).reversed())
+                .limit(RECENT_ACTIVITY_LIMIT)
+                .toList();
+    }
+
+    private RecentActivityItem toActivityItem(final Expense expense) {
+        return new RecentActivityItem(
+                "EXPENSE",
+                expense.getTitle(),
+                expense.getCreatedAt(),
+                expense.getAmount().negate(),
+                expense.getWallet().getName()
+        );
+    }
+
+    private RecentActivityItem toActivityItem(final Income income) {
+        return new RecentActivityItem(
+                "INCOME",
+                income.getTitle(),
+                income.getCreatedAt(),
+                income.getAmount(),
+                income.getWallet().getName()
+        );
+    }
+
+    private Map<Integer, BigDecimal> toMonthMap(
+            final List<MonthlyTotalProjection> projections
+    ) {
+        return projections.stream().collect(Collectors.toMap(
+                row -> row.getMonth().intValue(),
+                MonthlyTotalProjection::getTotal
+        ));
+    }
+
+    private Double calculatePercentageChange(
+            final BigDecimal previous, final BigDecimal current
+    ) {
+        if (previous == null || previous.compareTo(BigDecimal.ZERO) == 0) {
+            return current != null && current.compareTo(BigDecimal.ZERO) > 0
+                    ? NEW_ACTIVITY_PERCENTAGE : 0.0;
+        }
+        return current.subtract(previous)
+                .divide(
+                        previous.abs(),
+                        PERCENTAGE_SCALE,
+                        RoundingMode.HALF_EVEN
+                )
+                .multiply(PERCENTAGE_MULTIPLIER)
+                .setScale(PERCENTAGE_DISPLAY_SCALE, RoundingMode.HALF_EVEN)
+                .doubleValue();
+    }
+
+    /**
+     * Builds the "Spending this month" widget: total spent, spending as a
+     * percentage of total activity (income + expenses), and the top 3
+     * categories by share of total spending.
+     *
+     * @param userId the authenticated user's ID.
+     * @return the spending summary.
+     */
+    public SpendingSummaryResponse getSpendingSummary(final UUID userId) {
+        userService.validateUserActive(userId);
+        List<UUID> walletIds = repositoryWalletUser
+                .findWalletIdsByUserId(userId);
+
+        if (walletIds.isEmpty()) {
+            return new SpendingSummaryResponse(
+                    BigDecimal.ZERO, 0.0, List.of()
+            );
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate startOfMonth = today.withDayOfMonth(1);
+
+        BigDecimal totalExpense = repositoryExpense
+                .sumByWalletsAndDateRange(walletIds, startOfMonth, today);
+        BigDecimal totalIncome = repositoryIncome
+                .sumByWalletsAndDateRange(walletIds, startOfMonth, today);
+
+        BigDecimal totalActivity = totalExpense.add(totalIncome);
+        Double activityPercentage = totalActivity
+                .compareTo(BigDecimal.ZERO) == 0
+                ? 0.0
+                : totalExpense.divide(
+                        totalActivity, PERCENTAGE_SCALE, RoundingMode.HALF_EVEN)
+                .multiply(PERCENTAGE_MULTIPLIER)
+                .setScale(PERCENTAGE_DISPLAY_SCALE, RoundingMode.HALF_EVEN)
+                .doubleValue();
+
+        List<CategorySpendingProjection> topRaw = repositoryExpense
+                .sumGroupedByCategory(
+                        walletIds, startOfMonth, today,
+                        PageRequest.of(0, TOP_CATEGORIES_LIMIT)
+                );
+
+        List<CategoryPercentage> topCategories = topRaw.stream()
+                .map(row -> new CategoryPercentage(
+                        row.getCategoryId(),
+                        row.getCategoryName(),
+                        totalExpense.compareTo(BigDecimal.ZERO) == 0
+                                ? 0.0
+                                : row.getTotal().divide(
+                                        totalExpense, PERCENTAGE_SCALE,
+                                        RoundingMode.HALF_EVEN)
+                                .multiply(PERCENTAGE_MULTIPLIER)
+                                .setScale(PERCENTAGE_DISPLAY_SCALE,
+                                        RoundingMode.HALF_EVEN)
+                                .doubleValue()
+                ))
+                .toList();
+
+        return new SpendingSummaryResponse(
+                totalExpense, activityPercentage, topCategories
+        );
+    }
+
+    /**
+     * Builds the "Budgets health" widget: the 3 most recently updated
+     * budgets belonging to the user, with a display name derived from
+     * their wallet/category scope.
+     *
+     * @param userId the authenticated user's ID.
+     * @return up to 3 budget health items.
+     */
+    public List<BudgetHealthItem> getBudgetsHealth(final UUID userId) {
+        userService.validateUserActive(userId);
+
+        return repositoryBudget
+                .findTop3ByUserIdOrderByUpdatedAtDesc(userId)
+                .stream()
+                .map(budget -> new BudgetHealthItem(
+                        budget.getId(),
+                        resolveDisplayName(budget),
+                        budget.getUpdatedAt(),
+                        budget.getLastAlertStatus()
+                ))
+                .toList();
+    }
+
+    private String resolveDisplayName(final Budget budget) {
+        String walletName = budget.getWallet() != null
+                ? budget.getWallet().getName() : null;
+        String categoryName = budget.getCategory() != null
+                ? budget.getCategory().getName() : null;
+
+        if (walletName != null && categoryName != null) {
+            return walletName + " · " + categoryName;
+        }
+        if (walletName != null) {
+            return walletName;
+        }
+        if (categoryName != null) {
+            return categoryName;
+        }
+        return "Budget";
+    }
+}

--- a/src/main/java/bflow/dashboard/service/package-info.java
+++ b/src/main/java/bflow/dashboard/service/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains services for dashboard operations.
+ */
+package bflow.dashboard.service;

--- a/src/main/java/bflow/expenses/RepositoryExpense.java
+++ b/src/main/java/bflow/expenses/RepositoryExpense.java
@@ -1,5 +1,7 @@
 package bflow.expenses;
 
+import bflow.dashboard.projection.CategorySpendingProjection;
+import bflow.dashboard.projection.MonthlyTotalProjection;
 import bflow.expenses.entity.Expense;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,8 +47,9 @@ public interface RepositoryExpense extends JpaRepository<Expense, UUID> {
     );
 
     /**
-     * Sum expenses for a category within a date range.
+     * Sum expenses for a wallet and category within a date range.
      *
+     * @param walletId the wallet ID
      * @param categoryId the category ID
      * @param start the start date
      * @param end the end date
@@ -184,6 +187,16 @@ public interface RepositoryExpense extends JpaRepository<Expense, UUID> {
             Pageable pageable
     );
 
+    /**
+     * Finds expenses for a category across a set of wallets within a date
+     * range, ordered chronologically.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param categoryId the category ID
+     * @param start range start (inclusive)
+     * @param end range end (inclusive)
+     * @return matching expenses ordered by date ascending
+     */
     List<Expense>
     findByWalletIdInAndCategoryIdAndDateBetweenOrderByDateAsc(
             List<UUID> walletIds,
@@ -192,10 +205,93 @@ public interface RepositoryExpense extends JpaRepository<Expense, UUID> {
             LocalDate end
     );
 
+    /**
+     * Finds expenses for a category across a set of wallets within a date
+     * range, ordered by most recent first.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param categoryId the category ID
+     * @param start range start (inclusive)
+     * @param end range end (inclusive)
+     * @param pageable pagination configuration
+     * @return matching expenses ordered by date descending
+     */
     List<Expense>
     findByWalletIdInAndCategoryIdAndDateBetweenOrderByDateDescCreatedAtDesc(
             List<UUID> walletIds,
             UUID categoryId,
+            LocalDate start,
+            LocalDate end,
+            Pageable pageable
+    );
+
+    /**
+     * Sums expenses across a set of wallets within a date range.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param start range start (inclusive)
+     * @param end range end (inclusive)
+     * @return the sum of expenses
+     */
+    @Query("""
+    SELECT COALESCE(SUM(e.amount), 0)
+    FROM Expense e
+    WHERE e.wallet.id IN :walletIds
+    AND e.date BETWEEN :start AND :end
+""")
+    BigDecimal sumByWalletsAndDateRange(
+            List<UUID> walletIds, LocalDate start, LocalDate end);
+
+    /**
+     * Groups expenses by month within a date range.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param start range start (inclusive)
+     * @param end range end (inclusive)
+     * @return monthly expense totals
+     */
+    @Query("""
+    SELECT EXTRACT(MONTH FROM e.date) as month,
+           COALESCE(SUM(e.amount), 0) as total
+    FROM Expense e
+    WHERE e.wallet.id IN :walletIds
+    AND e.date BETWEEN :start AND :end
+    GROUP BY EXTRACT(MONTH FROM e.date)
+""")
+    List<MonthlyTotalProjection> sumGroupedByMonth(
+            List<UUID> walletIds, LocalDate start, LocalDate end);
+
+    /**
+     * Retrieves the most recent expenses across a set of wallets.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param pageable pagination configuration
+     * @return expenses ordered by creation date descending
+     */
+    List<Expense> findByWalletIdInOrderByCreatedAtDesc(
+            List<UUID> walletIds, Pageable pageable);
+
+    /**
+     * Groups expenses by category within a date range.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param start range start (inclusive)
+     * @param end range end (inclusive)
+     * @param pageable pagination configuration
+     * @return category spending totals ordered by amount descending
+     */
+    @Query("""
+    SELECT e.category.id as categoryId,
+           e.category.name as categoryName,
+           COALESCE(SUM(e.amount), 0) as total
+    FROM Expense e
+    WHERE e.wallet.id IN :walletIds
+    AND e.date BETWEEN :start AND :end
+    GROUP BY e.category.id, e.category.name
+    ORDER BY SUM(e.amount) DESC
+""")
+    List<CategorySpendingProjection> sumGroupedByCategory(
+            List<UUID> walletIds,
             LocalDate start,
             LocalDate end,
             Pageable pageable

--- a/src/main/java/bflow/expenses/services/ServiceExpense.java
+++ b/src/main/java/bflow/expenses/services/ServiceExpense.java
@@ -258,8 +258,8 @@ public class ServiceExpense {
         repositoryExpense.delete(expense);
 
         serviceBudget.evaluateBudgetsForExpenseEvent(
-                wallet.getId(),
-                expense.getCategory() != null ? expense.getCategory().getId() : null
+            wallet.getId(),
+            expense.getCategory() != null ? expense.getCategory().getId() : null
         );
     }
 

--- a/src/main/java/bflow/income/RepositoryIncome.java
+++ b/src/main/java/bflow/income/RepositoryIncome.java
@@ -1,5 +1,6 @@
 package bflow.income;
 
+import bflow.dashboard.projection.MonthlyTotalProjection;
 import bflow.income.entity.Income;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,7 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -40,4 +44,50 @@ public interface RepositoryIncome extends JpaRepository<Income, UUID> {
         "SELECT MAX(i.createdAt) FROM Income i WHERE i.wallet.id = :walletId"
     )
     Instant findMaxCreatedAtByWalletId(UUID walletId);
+
+    /**
+     * Sums incomes across a set of wallets within a date range.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param start range start (inclusive)
+     * @param end range end (inclusive)
+     * @return the sum of incomes
+     */
+    @Query("""
+    SELECT COALESCE(SUM(i.amount), 0)
+    FROM Income i
+    WHERE i.wallet.id IN :walletIds
+    AND i.date BETWEEN :start AND :end
+""")
+    BigDecimal sumByWalletsAndDateRange(
+            List<UUID> walletIds, LocalDate start, LocalDate end);
+
+    /**
+     * Groups incomes by month within a date range.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param start range start (inclusive)
+     * @param end range end (inclusive)
+     * @return monthly income totals
+     */
+    @Query("""
+    SELECT EXTRACT(MONTH FROM i.date) as month,
+           COALESCE(SUM(i.amount), 0) as total
+    FROM Income i
+    WHERE i.wallet.id IN :walletIds
+    AND i.date BETWEEN :start AND :end
+    GROUP BY EXTRACT(MONTH FROM i.date)
+""")
+    List<MonthlyTotalProjection> sumGroupedByMonth(
+            List<UUID> walletIds, LocalDate start, LocalDate end);
+
+    /**
+     * Retrieves the most recent incomes across a set of wallets.
+     *
+     * @param walletIds the wallet IDs to search
+     * @param pageable pagination configuration
+     * @return incomes ordered by creation date descending
+     */
+    List<Income> findByWalletIdInOrderByCreatedAtDesc(
+            List<UUID> walletIds, Pageable pageable);
 }

--- a/src/main/java/bflow/wallet/repository/RepositoryWallet.java
+++ b/src/main/java/bflow/wallet/repository/RepositoryWallet.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,4 +24,15 @@ public interface RepositoryWallet extends JpaRepository<Wallet, UUID> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT w FROM Wallet w WHERE w.id = :id")
     Optional<Wallet> findByIdForUpdate(UUID id);
+
+    /**
+     * Sums the current balance across the given wallets.
+     *
+     * @param walletIds the wallet identifiers to include
+     * @return the total balance
+     */
+    @Query(
+    "SELECT COALESCE(SUM(w.balance), 0) FROM Wallet w WHERE w.id IN :walletIds"
+    )
+    BigDecimal sumBalanceByWalletIds(List<UUID> walletIds);
 }

--- a/src/main/resources/db/migration/V14__add_name_and_picture_to_users.sql
+++ b/src/main/resources/db/migration/V14__add_name_and_picture_to_users.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users
+    ADD COLUMN name VARCHAR(255),
+    ADD COLUMN picture_url VARCHAR(500),
+    ADD COLUMN picture_source VARCHAR(20) NOT NULL DEFAULT 'NONE';
+
+ALTER TABLE users
+    ADD CONSTRAINT users_picture_source_check
+        CHECK (picture_source IN ('GOOGLE', 'S3', 'NONE'));

--- a/src/test/java/Diaz/Dev/BFlow/expenses/ServiceExpenseTest.java
+++ b/src/test/java/Diaz/Dev/BFlow/expenses/ServiceExpenseTest.java
@@ -191,7 +191,7 @@ class ServiceExpenseTest {
                 () -> serviceExpense.newExpense(request, userId));
 
         verify(repositoryExpense, never()).saveAndFlush(any(Expense.class));
-        verify(serviceBudget, never()).evaluateBudgetsForWallet(any());
+        verify(serviceBudget, never()).evaluateBudgetsForExpenseEvent(any(), any());
     }
 
     /**
@@ -229,7 +229,7 @@ class ServiceExpenseTest {
 
         assertNotNull(result);
         verify(repositoryExpense).saveAndFlush(any(Expense.class));
-        verify(serviceBudget).evaluateBudgetsForWallet(walletId);
+        verify(serviceBudget).evaluateBudgetsForExpenseEvent(eq(walletId), any());
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements per-widget REST endpoints backing the main dashboard screen (balance, spending, budgets health, statistics, averages, recent activity), plus the supporting `name`/`picture` profile fields synced from Cognito for the welcome widget.

## What's included

### New module: `bflow.dashboard`

- **`ServiceDashboard`** — aggregates data from `wallet`, `expenses`, `income`, and `budget` repositories. All widgets are scoped to *every wallet the authenticated user belongs to* (not a single selected wallet).
- **`ControllerDashboard`** — exposes one `GET` endpoint per widget under `/api/v1/dashboard/*`.
- New projections: `MonthlyTotalProjection`, `CategorySpendingProjection`.
- New DTOs: `BalanceSummaryResponse`, `SpendingSummaryResponse`, `CategoryPercentage`, `BudgetHealthItem`, `StatisticsResponse`, `MonthlyPoint`, `AveragesResponse`, `RecentActivityItem`.

### Endpoints

| Widget | Method | Route |
|---|---|---|
| Balance total | GET | `/api/v1/dashboard/balance` |
| Spending this month | GET | `/api/v1/dashboard/spending` |
| Budgets health (top 3) | GET | `/api/v1/dashboard/budgets-health` |
| Statistics (Jan–Dec) | GET | `/api/v1/dashboard/statistics?year=` |
| Averages (income/expense) | GET | `/api/v1/dashboard/averages` |
| Recent activity (top 5) | GET | `/api/v1/dashboard/recent-activity` |
| Welcome (name + picture) | GET | `/api/v1/auth/me` (existing endpoint, extended) |

### Repository additions

- `RepositoryWallet.sumBalanceByWalletIds`
- `RepositoryExpense` / `RepositoryIncome`: `sumByWalletsAndDateRange`, `sumGroupedByMonth` (PostgreSQL `EXTRACT(MONTH FROM ...)`, not `FUNCTION('MONTH', ...)` — MySQL syntax doesn't exist in Postgres), `findByWalletIdInOrderByCreatedAtDesc`
- `RepositoryExpense.sumGroupedByCategory` (top-N category spend)
- `RepositoryBudget.findTop3ByUserIdOrderByUpdatedAtDesc`

### User profile: `name` + `picture`

- New columns on `users`: `name`, `picture_url`, `picture_source` (`GOOGLE` / `S3` / `NONE`).
- `AuthSyncService` now captures `name`/`picture` claims from the Cognito ID token on every sync.
- `picture_source` guards against Cognito syncs overwriting a picture the user uploaded manually to S3 — sync only overwrites when source is `GOOGLE` or `NONE`, never `S3`.
- Verified Cognito Google IdP attribute mapping (`name`→`name`, `picture`→`picture`) and app client read permissions — both were already correctly configured.
- Existing Google-authenticated users backfill automatically on next login; no migration script needed for historical users.

## Known follow-ups (not blocking, tracked for later)

- **Multi-query cost per widget.** Endpoints like `/balance`, `/spending`, and `/averages` each run 2–4 independent aggregate queries (separate income/expense sums) instead of one consolidated query. Proposed fix: a single `FILTER (WHERE ...)`-based aggregate query per widget, consistent with the existing `UNION ALL` pattern used in the wallet transaction-history BFF.
- **No composite `GET /dashboard/summary` endpoint yet.** If the frontend loads all widgets on initial dashboard render, that's 6 separate HTTP round-trips today. A composite endpoint could cut that to one request while keeping the individual endpoints for targeted widget refreshes.
- **Multi-wallet dashboard scope is an implicit decision, not yet an ADR.** All widgets aggregate across every wallet the user belongs to. Worth formalizing before the frontend builds against this contract, in case a "dashboard scoped to one selected wallet" requirement surfaces later.
