### PR TITLE
fix(security): pin patched netty/httpcore5/postgresql versions, ignore unreachable pebble CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GitHub stars](https://img.shields.io/github/stars/DiazzzDev/BFlow-Backend-Open-Source?style=social)
 ![GitHub forks](https://img.shields.io/github/forks/DiazzzDev/BFlow-Backend-Open-Source?style=social)
 ![GitHub license](https://img.shields.io/github/license/DiazzzDev/BFlow-Backend-Open-Source)
-![CI](https://github.com/DiazzzDev/BFlow-Backend-Open-Source/actions/workflows/github-pipeline.yml/badge.svg)
+![CI](https://github.com/DiazzzDev/BFlow-Backend-Open-Source/actions/workflows/ci.yml/badge.svg)
 ![contributors](https://img.shields.io/github/contributors/DiazzzDev/BFlow-Backend-Open-Source)
 
 
@@ -65,9 +65,9 @@ Implemented:
 - Budget rules engine
 - Rate limiter
 - Idempotency layer
+- Payment integration via Wompi
 
 Roadmap:
-- Payment integration via Wompi
 - OpenTelemetry integration
 - Shared wallet roles
 - Redis-based caching

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,41 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+
+			<!-- Security overrides: pin patched versions above whatever the AWS SDK/
+			     Spring Boot BOMs currently resolve to. See Trivy findings in CI.
+			     Remove an override once the parent BOM catches up to (or exceeds)
+			     the fixed version pinned here. -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-compression</artifactId>
+				<version>4.2.16.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-http</artifactId>
+				<version>4.2.16.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-http2</artifactId>
+				<version>4.2.16.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents.core5</groupId>
+				<artifactId>httpcore5</artifactId>
+				<version>5.4.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents.core5</groupId>
+				<artifactId>httpcore5-h2</artifactId>
+				<version>5.4.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.postgresql</groupId>
+				<artifactId>postgresql</artifactId>
+				<version>42.7.12</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>Fixes 8 HIGH-severity CVEs flagged by Trivy in <code>app.jar</code>, and adds justified ignores for 7 HIGH CVEs in <code>usr/bin/pebble</code> (bundled in the Ubuntu 26.04 base image under <code>eclipse-temurin:21-jre</code>, never invoked by our container).</p>
<h2>What changed</h2>
<p><strong><code>pom.xml</code></strong> - added explicit <code>dependencyManagement</code> overrides. Bumping the AWS SDK BOM to 2.53.3 alone did not fix these, since none of the three libraries below are managed by that BOM:</p>

Library | Was | Now | CVEs fixed
-- | -- | -- | --
io.netty:netty-codec-compression | 4.2.15.Final | 4.2.16.Final | CVE-2026-59901 (infinite loop, bzip2)
io.netty:netty-codec-http | 4.2.15.Final | 4.2.16.Final | CVE-2026-55831, CVE-2026-55833, CVE-2026-56745 (SPDY DoS)
io.netty:netty-codec-http2 | 4.2.15.Final | 4.2.16.Final | CVE-2026-56819 (HTTP/2 memory leak)
org.apache.httpcomponents.core5:httpcore5 | 5.4.2 | 5.4.3 | CVE-2026-54399 (DoS via excessive headers)
org.apache.httpcomponents.core5:httpcore5-h2 | 5.4.2 | 5.4.3 | CVE-2026-54428 (DoS via oversized HPACK header)
org.postgresql:postgresql | 42.7.11 | 42.7.12 | CVE-2026-54291 (SCRAM-SHA-256-PLUS MITM downgrade)


<p>The <code>postgresql</code> bump is the one worth flagging specifically: it fixes a man-in-the-middle protection bypass in the JDBC driver's SCRAM auth handshake, and lands right as we've moved the production database connection to Supabase (<code>#75</code>).</p>
<p><strong><code>.trivyignore</code></strong> - added the 7 <code>usr/bin/pebble</code> CVEs (CVE-2026-33818, CVE-2026-46600, CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860, CVE-2026-56862), all in Go's stdlib bundled inside a Canonical service-manager binary that ships in the Ubuntu 26.04 base image. Not part of our execution path - the Dockerfile's <code>ENTRYPOINT</code> runs <code>java -jar app.jar</code> directly and never invokes pebble. Documented with a re-check note for whenever the base image is updated.</p>
<h2>Verification</h2>
<ul>
<li><code>./mvnw dependency:tree -Dincludes=io.netty:netty-codec-http,io.netty:netty-codec-http2,io.netty:netty-codec-compression,org.apache.httpcomponents.core5:httpcore5,org.apache.httpcomponents.core5:httpcore5-h2,org.postgresql:postgresql</code> confirms all six resolve to the patched versions above.</li>
<li>Re-ran the <code>security.yml</code> Trivy scan - <code>app.jar</code> and <code>usr/bin/pebble</code> both report 0 findings.</li>
</ul>
<h2>Out of scope</h2>
<p>No changes to application code, Flyway migrations, Cognito, S3, SES, or infrastructure.</p></body></html><!--EndFragment-->
</body>
</html>