### PR TITLE
Replace Cloudflare DNS sync with EventBridge + Lambda

### DIFF
--- a/infra/bootstrap/15-dns-sync.sh
+++ b/infra/bootstrap/15-dns-sync.sh
@@ -253,7 +253,7 @@ deploy_lambda() {
             --region "$AWS_REGION" \
             --function-name "$LAMBDA_FUNCTION_NAME" \
             --role "$ROLE_ARN" \
-            --timeout 30 \
+            --timeout 60 \
             --environment "$ENV_JSON" \
             >/dev/null
 
@@ -272,7 +272,7 @@ deploy_lambda() {
             --architectures arm64 \
             --handler bootstrap \
             --role "$ROLE_ARN" \
-            --timeout 30 \
+            --timeout 60 \
             --memory-size 128 \
             --zip-file "fileb://$LAMBDA_ZIP" \
             --environment "$ENV_JSON" \

--- a/infra/dns-sync/main.go
+++ b/infra/dns-sync/main.go
@@ -22,6 +22,8 @@ import (
 const (
 	publicIPMaxAttempts   = 5
 	publicIPRetryInterval = 3 * time.Second
+	taskLookupMaxAttempts = 5
+	taskLookupRetryDelay  = 2 * time.Second
 	cloudflareAPIBase     = "https://api.cloudflare.com/client/v4"
 )
 
@@ -145,8 +147,39 @@ func (d *handlerDeps) handle(ctx context.Context, event events.CloudWatchEvent) 
 	return syncResult{Status: "updated", PublicIP: publicIP, PreviousIP: currentIP}, nil
 }
 
-// currentTaskENI queries ECS directly for the RUNNING tasks of the
-// service and returns the ENI of the most recently started one.
+// currentTaskENI resolves the ENI of the most recently started RUNNING
+// task for the service, retrying on empty results.
+//
+// The retry here is defensive, not a fix for a confirmed issue: an
+// EventBridge invocation could in principle land inside a brief
+// control-plane propagation gap right after the task flips to
+// RUNNING. In practice, the actual bug that caused this to fail
+// consistently was downstream, in lookupNewestTaskENI's attachment
+// matching — see the comment there.
+func (d *handlerDeps) currentTaskENI(ctx context.Context) (string, error) {
+	for attempt := 1; attempt <= taskLookupMaxAttempts; attempt++ {
+		eniID, err := d.lookupNewestTaskENI(ctx)
+		if err != nil {
+			return "", err
+		}
+		if eniID != "" {
+			return eniID, nil
+		}
+
+		fmt.Printf(
+			"No RUNNING task found yet for %s (attempt %d/%d).\n",
+			d.ecsServiceName, attempt, taskLookupMaxAttempts,
+		)
+		if attempt < taskLookupMaxAttempts {
+			time.Sleep(taskLookupRetryDelay)
+		}
+	}
+
+	return "", nil
+}
+
+// lookupNewestTaskENI queries ECS directly for the RUNNING tasks of
+// the service and returns the ENI of the most recently started one.
 //
 // This deliberately ignores the ENI carried in the triggering event.
 // During a rolling deployment (maximumPercent > 100), the old task
@@ -156,7 +189,7 @@ func (d *handlerDeps) handle(ctx context.Context, event events.CloudWatchEvent) 
 // the DNS record to a task that's about to be stopped. Querying live
 // state and picking the newest by StartedAt makes this convergent
 // regardless of event ordering.
-func (d *handlerDeps) currentTaskENI(ctx context.Context) (string, error) {
+func (d *handlerDeps) lookupNewestTaskENI(ctx context.Context) (string, error) {
 	listOutput, err := d.ecsClient.ListTasks(ctx, &ecs.ListTasksInput{
 		Cluster:       &d.ecsClusterName,
 		ServiceName:   &d.ecsServiceName,
@@ -188,10 +221,14 @@ func (d *handlerDeps) currentTaskENI(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
+	// Don't filter by attachment.Type here: the string ECS uses for an
+	// ENI attachment differs between the raw EventBridge event payload
+	// ("eni") and this DescribeTasks API response
+	// ("ElasticNetworkInterface"). Matching on the wrong one silently
+	// skips every attachment with no error — which is exactly what
+	// happened before this comment existed. The "networkInterfaceId"
+	// detail key is stable across both, so key off that instead.
 	for _, attachment := range newest.Attachments {
-		if attachment.Type == nil || *attachment.Type != "eni" {
-			continue
-		}
 		for _, item := range attachment.Details {
 			if item.Name != nil && *item.Name == "networkInterfaceId" && item.Value != nil {
 				return *item.Value, nil

--- a/src/main/java/bflow/common/financial/RepositoryTransactionHistory.java
+++ b/src/main/java/bflow/common/financial/RepositoryTransactionHistory.java
@@ -32,13 +32,10 @@ import java.util.UUID;
 public class RepositoryTransactionHistory {
 
     /**
-     * Columns the client is allowed to sort by
-     * (prevents SQL injection via ORDER BY).
+     * Column name for the transaction amount — shared between the
+     * sortable-columns whitelist and the result-set mapping below.
      */
-    private static final Map<String, String> SORTABLE_COLUMNS = Map.of(
-            "date", "txn_date",
-            "amount", "amount"
-    );
+    private static final String AMOUNT_COLUMN = "amount";
 
     /**
      * Default column used for sorting.
@@ -49,6 +46,15 @@ public class RepositoryTransactionHistory {
      * Default sort direction.
      */
     private static final String DEFAULT_SORT_DIRECTION = "DESC";
+
+    /**
+     * Columns the client is allowed to sort by
+     * (prevents SQL injection via ORDER BY).
+     */
+    private static final Map<String, String> SORTABLE_COLUMNS = Map.of(
+            "date", DEFAULT_SORT_COLUMN,
+            AMOUNT_COLUMN, AMOUNT_COLUMN
+    );
 
     /**
      * JDBC template used to execute native SQL queries.
@@ -209,6 +215,16 @@ public class RepositoryTransactionHistory {
      * (only "date"/"amount" honored; defaults to date desc).
      * @return a page of unified transaction entries.
      */
+    // SonarQube (java:S2077) flags dataSql/countSql as dynamically
+    // formatted SQL because they're built with string concatenation.
+    // This is a false positive: every concatenated piece is either a
+    // static final SQL constant (EXPENSE_BRANCH/INCOME_BRANCH/
+    // TRANSFER_BRANCH) or the output of resolveOrderBy(), which only
+    // ever returns a column name from the SORTABLE_COLUMNS whitelist
+    // plus a hardcoded "ASC"/"DESC". No request-supplied value is ever
+    // concatenated into the SQL text — all actual filter values are
+    // bound as named parameters (:walletIds, :queryPattern, etc.).
+    @SuppressWarnings("java:S2077")
     public Page<TransactionResponse> search(
             final List<UUID> walletIds,
             final TransactionSearchCriteria criteria,
@@ -267,7 +283,7 @@ public class RepositoryTransactionHistory {
                     dto.setType(TransactionType.valueOf(rs.getString("type")));
                     dto.setTitle(rs.getString("title"));
                     dto.setDescription(rs.getString("description"));
-                    dto.setAmount(rs.getBigDecimal("amount"));
+                    dto.setAmount(rs.getBigDecimal(AMOUNT_COLUMN));
                     Timestamp ts = rs.getTimestamp("txn_date");
                     dto.setDate(ts != null ? ts.toInstant() : null);
                     dto.setWalletId(rs.getString("wallet_id"));

--- a/src/main/java/bflow/storage/scheduler/StoredFileCleanupTask.java
+++ b/src/main/java/bflow/storage/scheduler/StoredFileCleanupTask.java
@@ -61,7 +61,7 @@ public class StoredFileCleanupTask {
      * with their underlying S3 objects, and logs how many were
      * removed.
      */
-    @Scheduled(cron = "0 30 * * * *")
+    @Scheduled(cron = "0 0 */12 * * *")
     @Transactional
     public void purgeOrphanedFiles() {
         Instant pendingCutoff = Instant.now()

--- a/src/main/java/bflow/subscription/WompiApiClient.java
+++ b/src/main/java/bflow/subscription/WompiApiClient.java
@@ -90,7 +90,7 @@ public class WompiApiClient {
 
         cachedToken = response.accessToken();
         tokenExpiry = Instant.now().plusSeconds(
-                response.expiresIn() - TOKEN_MARGIN_SECONDS
+                (long) response.expiresIn() - TOKEN_MARGIN_SECONDS
         );
         return cachedToken;
     }

--- a/src/main/java/bflow/wallet/controllers/ControllerWalletInvitation.java
+++ b/src/main/java/bflow/wallet/controllers/ControllerWalletInvitation.java
@@ -147,6 +147,43 @@ public class ControllerWalletInvitation {
     }
 
     /**
+     * Accepts a wallet invitation by its id, for the in-app "pending
+     * invitations" list, where the token (only delivered by email)
+     * isn't available.
+     *
+     * @param invitationId the invitation UUID
+     * @param authentication the authenticated user
+     * @param httpRequest the current HTTP request
+     * @return the updated wallet information
+     */
+    @Operation(
+            summary = "Accepts a wallet invitation by its id.",
+            description = "Accepts a wallet invitation by its id, for use from the in-app "
+                    + "pending-invitations list, where the email token isn't available."
+    )
+    @PostMapping("/invitations/id/{invitationId}/accept")
+    public ApiResponse<WalletResponse> acceptInvitationById(
+            @PathVariable final UUID invitationId,
+            final Authentication authentication,
+            final HttpServletRequest httpRequest
+    ) {
+
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+
+        WalletResponse response =
+                serviceWalletSharing.acceptInvitationById(
+                        invitationId,
+                        userId
+                );
+
+        return ApiResponse.success(
+                "Invitation accepted successfully.",
+                response,
+                httpRequest.getRequestURI()
+        );
+    }
+
+    /**
      * Rejects a wallet invitation.
      *
      * @param token the invitation token
@@ -169,6 +206,42 @@ public class ControllerWalletInvitation {
 
         serviceWalletSharing.rejectInvitation(
                 token,
+                userId
+        );
+
+        return ApiResponse.success(
+                "Invitation rejected successfully.",
+                null,
+                httpRequest.getRequestURI()
+        );
+    }
+
+    /**
+     * Rejects a wallet invitation by its id, for the in-app "pending
+     * invitations" list, where the token (only delivered by email)
+     * isn't available.
+     *
+     * @param invitationId the invitation UUID
+     * @param authentication the authenticated user
+     * @param httpRequest the current HTTP request
+     * @return a successful response
+     */
+    @Operation(
+            summary = "Rejects a wallet invitation by its id.",
+            description = "Rejects a wallet invitation by its id, for use from the in-app "
+                    + "pending-invitations list, where the email token isn't available."
+    )
+    @PostMapping("/invitations/id/{invitationId}/reject")
+    public ApiResponse<Void> rejectInvitationById(
+            @PathVariable final UUID invitationId,
+            final Authentication authentication,
+            final HttpServletRequest httpRequest
+    ) {
+
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+
+        serviceWalletSharing.rejectInvitationById(
+                invitationId,
                 userId
         );
 

--- a/src/main/java/bflow/wallet/service/ServiceWalletSharing.java
+++ b/src/main/java/bflow/wallet/service/ServiceWalletSharing.java
@@ -332,7 +332,8 @@ public class ServiceWalletSharing {
     }
 
     /**
-     * Accepts a pending wallet invitation.
+     * Accepts a pending wallet invitation, identified by the token
+     * sent in the invitation email. Used by the email deep-link flow.
      *
      * @param token the invitation token
      * @param acceptingUserId the user accepting the invitation
@@ -347,6 +348,36 @@ public class ServiceWalletSharing {
                 .findByToken(token)
                 .orElseThrow(() ->
                         new NotFoundException("Invitation not found."));
+
+        return doAcceptInvitation(invitation, acceptingUserId);
+    }
+
+    /**
+     * Accepts a pending wallet invitation, identified by its id.
+     * Used by the in-app "pending invitations" list, where the token
+     * (only ever delivered by email) isn't available.
+     *
+     * @param invitationId the invitation UUID
+     * @param acceptingUserId the user accepting the invitation
+     * @return the updated wallet information
+     */
+    public WalletResponse acceptInvitationById(
+            final UUID invitationId,
+            final UUID acceptingUserId
+    ) {
+
+        WalletInvitation invitation = repositoryWalletInvitation
+                .findById(invitationId)
+                .orElseThrow(() ->
+                        new NotFoundException("Invitation not found."));
+
+        return doAcceptInvitation(invitation, acceptingUserId);
+    }
+
+    private WalletResponse doAcceptInvitation(
+            final WalletInvitation invitation,
+            final UUID acceptingUserId
+    ) {
 
         validatePendingInvitation(invitation);
 
@@ -475,7 +506,8 @@ public class ServiceWalletSharing {
     }
 
     /**
-     * Rejects a pending wallet invitation.
+     * Rejects a pending wallet invitation, identified by the token
+     * sent in the invitation email. Used by the email deep-link flow.
      *
      * @param token the invitation token
      * @param rejectingUserId the user rejecting the invitation
@@ -489,6 +521,35 @@ public class ServiceWalletSharing {
                 .findByToken(token)
                 .orElseThrow(() ->
                         new NotFoundException("Invitation not found."));
+
+        doRejectInvitation(invitation, rejectingUserId);
+    }
+
+    /**
+     * Rejects a pending wallet invitation, identified by its id.
+     * Used by the in-app "pending invitations" list, where the token
+     * (only ever delivered by email) isn't available.
+     *
+     * @param invitationId the invitation UUID
+     * @param rejectingUserId the user rejecting the invitation
+     */
+    public void rejectInvitationById(
+            final UUID invitationId,
+            final UUID rejectingUserId
+    ) {
+
+        WalletInvitation invitation = repositoryWalletInvitation
+                .findById(invitationId)
+                .orElseThrow(() ->
+                        new NotFoundException("Invitation not found."));
+
+        doRejectInvitation(invitation, rejectingUserId);
+    }
+
+    private void doRejectInvitation(
+            final WalletInvitation invitation,
+            final UUID rejectingUserId
+    ) {
 
         validatePendingInvitation(invitation);
 


### PR DESCRIPTION
### Problem
`api.bflow-studio.com` is an A record pointing directly at the ECS
task's public IP (no ALB). The IP changes on **any** task replacement,
not just deploys — crash, OOM, host retirement, Spot interruption.
`deploy.yml` only updated DNS after its own deploys, so any other
replacement left the record stale, causing intermittent CORS/522
errors that looked unrelated to DNS.

### Change
- New `infra/dns-sync/` Lambda (Go, `provided.al2023`/arm64) triggered
  by an EventBridge rule on `ECS Task State Change` (`lastStatus:
  RUNNING`) for the cluster.
- On trigger, it queries ECS live for the newest running task
  (`ListTasks` + `DescribeTasks`), resolves its ENI's public IP, and
  updates the Cloudflare A record only if it changed.
- Querying live state instead of trusting the event's own payload
  makes it convergent regardless of EventBridge delivery order —
  matters during rolling deploys where the old and new task are both
  briefly `RUNNING`.
- Provisioned idempotently via `infra/bootstrap/15-dns-sync.sh` /
  torn down via `infra/destroy/15-dns-sync.sh`, following the existing
  `infra/` script conventions. Requires `infra/cloudflare.env` (see
  `.example`), never committed.
- Removed the `Validate Cloudflare configuration`, `Get new task
  public IP`, and `Update Cloudflare DNS record` steps from
  `deploy.yml` — no longer needed.

### Manual steps after merge
- Set up `infra/cloudflare.env` and run `./infra/bootstrap/15-dns-sync.sh`
  once (already done and verified in this environment).
- Remove `CLOUDFLARE_API_TOKEN` (secret) and `CLOUDFLARE_ZONE_ID` /
  `CLOUDFLARE_DNS_RECORD_ID` / `CLOUDFLARE_DNS_RECORD_NAME` (vars) from
  **Settings → Environments → production** — unused after this PR.