### PR TITLE
fix: avatar upload 503 (IAM) + display name overwritten by /auth/sync

### DIFF
--- a/infra/s3/05-configure-iam.sh
+++ b/infra/s3/05-configure-iam.sh
@@ -9,9 +9,6 @@
 # place, so re-running this script with the same inputs always produces
 # the same policy document.
 #
-###################################
-# Not tested yet
-###################################
 
 set -euo pipefail
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>bom</artifactId>
-				<version>2.53.3</version>
+				<version>2.54.4</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/main/java/bflow/auth/DTO/Record/SyncUserResponse.java
+++ b/src/main/java/bflow/auth/DTO/Record/SyncUserResponse.java
@@ -1,6 +1,7 @@
 package bflow.auth.DTO.Record;
 
 import bflow.auth.DTO.user.UserProfileResponse;
+import bflow.subscription.dto.CurrentSubscriptionResponse;
 import bflow.subscription.dto.SubscriptionResponse;
 import bflow.wallet.DTO.WalletResponse;
 
@@ -15,6 +16,12 @@ import java.util.UUID;
  * @param roles user roles
  * @param isNewUser whether the user was created during synchronization
  * @param subscription current user subscription
+ * @param plan the user's current plan — code, name, status, and the
+ *         feature flags/limits it grants, mirroring what
+ *         {@code GET /api/v1/subscriptions/current} returns.
+ *         {@code null} if it couldn't be resolved (should not
+ *         normally happen; every user gets a free plan on
+ *         registration).
  * @param wallets wallets belonging to the user
  * @param profile user profile information
  */
@@ -24,6 +31,7 @@ public record SyncUserResponse(
         List<String> roles,
         boolean isNewUser,
         SubscriptionResponse subscription,
+        CurrentSubscriptionResponse plan,
         List<WalletResponse> wallets,
         UserProfileResponse profile
 ) { }

--- a/src/main/java/bflow/auth/entities/User.java
+++ b/src/main/java/bflow/auth/entities/User.java
@@ -1,5 +1,6 @@
 package bflow.auth.entities;
 
+import bflow.auth.enums.NameSource;
 import bflow.auth.enums.PictureSource;
 import bflow.auth.enums.UserStatus;
 import jakarta.persistence.CollectionTable;
@@ -49,6 +50,12 @@ public class User {
     /** Display name of the user, captured from the Cognito ID token. */
     @Column
     private String name;
+
+    /** Origin of the current display name. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "name_source", nullable = false)
+    @Builder.Default
+    private NameSource nameSource = NameSource.GOOGLE;
 
     /** URL of the user's profile picture. */
     @Column(name = "picture_url")

--- a/src/main/java/bflow/auth/enums/NameSource.java
+++ b/src/main/java/bflow/auth/enums/NameSource.java
@@ -1,0 +1,12 @@
+package bflow.auth.enums;
+
+/**
+ * Origin of the user's display name. Determines whether the Cognito
+ * sync flow is allowed to overwrite it.
+ */
+public enum NameSource {
+    /** Name sourced from Google's OAuth profile claim. */
+    GOOGLE,
+    /** Name manually set by the user via {@code PATCH /me}. */
+    USER
+}

--- a/src/main/java/bflow/auth/mapper/UserMapper.java
+++ b/src/main/java/bflow/auth/mapper/UserMapper.java
@@ -3,22 +3,44 @@ package bflow.auth.mapper;
 import bflow.auth.DTO.UserMeResponse;
 import bflow.auth.DTO.user.UserProfileResponse;
 import bflow.auth.entities.User;
+import bflow.subscription.dto.SubscriptionResponse;
+import bflow.subscription.entities.Subscription;
+import bflow.subscription.enums.SubscriptionStatus;
+import bflow.subscription.repository.RepositorySubscription;
+import bflow.wallet.DTO.WalletResponse;
+import bflow.wallet.repository.RepositoryWalletUser;
+import bflow.wallet.service.ServiceWallet;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Maps User entities to their public-facing response DTOs.
  */
 @Component
+@RequiredArgsConstructor
 public class UserMapper {
 
     /**
+     * Repository used to resolve the user's subscription.
+     */
+    private final RepositorySubscription repositorySubscription;
+
+    /**
+     * Repository used to resolve the user's wallet memberships.
+     */
+    private final RepositoryWalletUser repositoryWalletUser;
+
+    /**
+     * Service used to map a wallet membership into its public DTO.
+     */
+    private final ServiceWallet serviceWallet;
+
+    /**
      * Builds the "/auth/me" response for the given user.
-     *
-     * <p>Subscription and wallets are intentionally left {@code null}/
-     * empty here — they are populated by their respective services once
-     * that wiring is in place, not by this mapper.
      *
      * @param user the authenticated user entity
      * @return the assembled response DTO
@@ -27,10 +49,42 @@ public class UserMapper {
         return new UserMeResponse(
                 user.getId(),
                 List.copyOf(user.getRoles()),
-                null,
-                List.of(),
+                resolveSubscription(user.getId()),
+                resolveWallets(user.getId()),
                 toProfileResponse(user)
         );
+    }
+
+    /**
+     * Resolves the user's current subscription — active if one
+     * exists, otherwise past-due, otherwise {@code null} (a user can
+     * legitimately have neither yet, e.g. right before the
+     * registration bootstrap that grants the free plan runs).
+     *
+     * @param userId the user identifier
+     * @return the current subscription, or {@code null}
+     */
+    private SubscriptionResponse resolveSubscription(final UUID userId) {
+        Optional<Subscription> subscription = repositorySubscription
+                .findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)
+                .or(() -> repositorySubscription.findByUserIdAndStatus(
+                        userId, SubscriptionStatus.PAST_DUE
+                ));
+
+        return subscription.map(SubscriptionResponse::from).orElse(null);
+    }
+
+    /**
+     * Resolves every wallet the user belongs to.
+     *
+     * @param userId the user identifier
+     * @return the user's wallets
+     */
+    private List<WalletResponse> resolveWallets(final UUID userId) {
+        return repositoryWalletUser.findByUserId(userId)
+                .stream()
+                .map(serviceWallet::convertToDTO)
+                .toList();
     }
 
     /**

--- a/src/main/java/bflow/auth/services/AuthSyncService.java
+++ b/src/main/java/bflow/auth/services/AuthSyncService.java
@@ -9,17 +9,22 @@ import bflow.auth.enums.UserStatus;
 import bflow.auth.mapper.UserMapper;
 import bflow.auth.repository.RepositoryUser;
 import bflow.auth.security.CognitoIdTokenValidator;
+import bflow.subscription.dto.CurrentSubscriptionResponse;
+import bflow.subscription.services.PlanLimitService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Synchronizes Cognito users with the local database.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthSyncService {
@@ -43,6 +48,12 @@ public class AuthSyncService {
      * Mapper for building user-facing response DTOs.
      */
     private final UserMapper userMapper;
+
+    /**
+     * Service used to resolve the user's current plan (code, name,
+     * status, feature flags, and limits) for the sync response.
+     */
+    private final PlanLimitService planLimitService;
 
     /**
      * Synchronizes the authenticated Cognito user with the local database
@@ -113,7 +124,6 @@ public class AuthSyncService {
                 .build();
 
         repositoryUser.save(newUser);
-        authBootstrapService.bootstrap(newUser);
 
         return buildResponse(newUser, true);
     }
@@ -121,6 +131,15 @@ public class AuthSyncService {
     /**
      * Builds the session response returned after authentication
      * synchronization.
+     *
+     * Self-heals accounts missing their default wallet or free
+     * subscription — both {@link AuthBootstrapService#bootstrap}
+     * steps are idempotent, so this is safe (and cheap) to call for
+     * every sync, not only brand-new users. This matters because
+     * bootstrap previously only ran on first-ever registration:
+     * any account created another way (pre-dating the subscriptions
+     * feature, a data migration, etc.) never got a subscription row
+     * and would otherwise be stuck with a {@code null} plan forever.
      *
      * @param user authenticated user
      * @param isNewUser whether the user was created during synchronization
@@ -130,6 +149,8 @@ public class AuthSyncService {
             final User user,
             final boolean isNewUser
     ) {
+        authBootstrapService.bootstrap(user);
+
         UserMeResponse meResponse = userMapper.toMeResponse(user);
 
         return new SyncUserResponse(
@@ -138,9 +159,41 @@ public class AuthSyncService {
                 meResponse.roles(),
                 isNewUser,
                 meResponse.subscription(),
+                resolveCurrentPlan(user.getId()),
                 meResponse.wallets(),
                 meResponse.profile()
         );
+    }
+
+    /**
+     * Resolves the user's current plan for the sync response.
+     *
+     * Every user gets a free plan on registration (see
+     * {@link AuthBootstrapService#bootstrap}) and the free plan can
+     * never be canceled, so this should always succeed in practice.
+     * It's still wrapped defensively — sync sits on the critical
+     * login path, so a plan-resolution edge case (e.g. stale data
+     * from a migration) degrades to a {@code null} plan instead of
+     * failing the whole sign-in.
+     *
+     * @param userId the user identifier
+     * @return the current plan, or {@code null} if it couldn't be
+     *         resolved
+     */
+    private CurrentSubscriptionResponse resolveCurrentPlan(
+            final UUID userId
+    ) {
+        try {
+            return planLimitService.getCurrentSubscriptionInfo(userId);
+        } catch (IllegalStateException ex) {
+            log.warn(
+                    "Could not resolve current plan for user {} during "
+                            + "sync: {}",
+                    userId,
+                    ex.getMessage()
+            );
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/bflow/auth/services/AuthSyncService.java
+++ b/src/main/java/bflow/auth/services/AuthSyncService.java
@@ -4,6 +4,7 @@ import bflow.auth.DTO.Record.SyncUserRequest;
 import bflow.auth.DTO.Record.SyncUserResponse;
 import bflow.auth.DTO.UserMeResponse;
 import bflow.auth.entities.User;
+import bflow.auth.enums.NameSource;
 import bflow.auth.enums.PictureSource;
 import bflow.auth.enums.UserStatus;
 import bflow.auth.mapper.UserMapper;
@@ -209,7 +210,10 @@ public class AuthSyncService {
             final String name,
             final String picture
     ) {
-        if (name != null && !name.isBlank()) {
+        boolean canOverwriteName =
+                user.getNameSource() != NameSource.USER;
+
+        if (name != null && !name.isBlank() && canOverwriteName) {
             user.setName(name);
         }
 

--- a/src/main/java/bflow/auth/services/UserService.java
+++ b/src/main/java/bflow/auth/services/UserService.java
@@ -3,6 +3,7 @@ package bflow.auth.services;
 import bflow.auth.DTO.user.UpdateUserProfileRequest;
 import bflow.auth.DTO.user.UserProfileResponse;
 import bflow.auth.entities.User;
+import bflow.auth.enums.NameSource;
 import bflow.auth.enums.UserStatus;
 import bflow.auth.repository.RepositoryUser;
 import java.util.UUID;
@@ -56,6 +57,7 @@ public class UserService {
 
         if (request.getName() != null) {
             user.setName(request.getName().trim());
+            user.setNameSource(NameSource.USER);
         }
 
         userRepository.save(user);

--- a/src/main/java/bflow/budget/services/BudgetService.java
+++ b/src/main/java/bflow/budget/services/BudgetService.java
@@ -903,9 +903,7 @@ public class BudgetService {
             BudgetResponse endResponse = calculationService.calculate(budget);
 
             if (endResponse.getStatus() != BudgetStatus.EXCEEDED) {
-                notificationService.sendBudgetSuccess(
-                        budget.getUser().getId(), endResponse
-                );
+                notifySuccess(budget, endResponse);
             }
 
             lifecycleService.resetBudgetPeriod(budget);
@@ -926,6 +924,44 @@ public class BudgetService {
         alertService.evaluate(response, budget.getUser().getId(), budget);
 
         repositoryBudget.save(budget);
+    }
+
+    /**
+     * Notifies about a completed, non-exceeded budget period. If the
+     * budget is tied to a shared wallet (scope WALLET or
+     * WALLET_CATEGORY) with more than one member, every member gets
+     * a team celebration instead of just the budget's owner —
+     * turning "stayed on budget" into a shared win rather than a
+     * private one. CATEGORY_GLOBAL budgets and single-member wallets
+     * keep the existing personal notification.
+     *
+     * @param budget the budget whose period just ended
+     * @param response the final calculated figures for the period
+     */
+    private void notifySuccess(
+            final Budget budget,
+            final BudgetResponse response
+    ) {
+        if (budget.getWallet() != null) {
+            List<WalletUser> walletMembers = repositoryWalletUser
+                    .findByWalletId(budget.getWallet().getId());
+
+            if (walletMembers.size() > 1) {
+                List<User> members = walletMembers.stream()
+                        .map(WalletUser::getUser)
+                        .distinct()
+                        .toList();
+
+                notificationService.sendBudgetGroupSuccess(
+                        members, budget.getWallet().getName(), response
+                );
+                return;
+            }
+        }
+
+        notificationService.sendBudgetSuccess(
+                budget.getUser().getId(), response
+        );
     }
 
     /**

--- a/src/main/java/bflow/common/aws/service/EmailTemplateService.java
+++ b/src/main/java/bflow/common/aws/service/EmailTemplateService.java
@@ -289,4 +289,40 @@ public final class EmailTemplateService {
                 html
         );
     }
+
+    /**
+     * Sends a contact form message to the configured support email.
+     *
+     * @param senderName name of the person submitting the form
+     * @param senderEmail email address of the person submitting the form
+     * @param subject subject provided by the sender
+     * @param message message provided by the sender
+     */
+    public void sendContactMessage(
+            final String senderName,
+            final String senderEmail,
+            final String subject,
+            final String message
+    ) {
+        Context context = new Context();
+
+        context.setVariable("senderName", senderName);
+        context.setVariable("senderEmail", senderEmail);
+        context.setVariable("subject", subject);
+        context.setVariable("message", message);
+        context.setVariable("year", Year.now().getValue());
+        context.setVariable("supportEmail", supportEmail);
+        context.setVariable("logoUrl", logoUrl);
+
+        String html = templateEngine.process(
+                "contact-message",
+                context
+        );
+
+        sesEmailService.sendEmail(
+                supportEmail,
+                "[BFlow Contact] " + subject,
+                html
+        );
+    }
 }

--- a/src/main/java/bflow/common/aws/service/EmailTemplateService.java
+++ b/src/main/java/bflow/common/aws/service/EmailTemplateService.java
@@ -1,5 +1,6 @@
 package bflow.common.aws.service;
 
+import bflow.budget.DTO.BudgetResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -250,5 +251,42 @@ public final class EmailTemplateService {
                 : "We couldn't process \"" + transactionTitle + "\"";
 
         sesEmailService.sendEmail(toEmail, subject, html);
+    }
+
+    /**
+     * Sends a celebratory email to one member of a shared wallet when
+     * that wallet stays within budget as a team for the period.
+     *
+     * @param toEmail recipient email address
+     * @param userName recipient display name
+     * @param walletName the shared wallet's name
+     * @param budget the final budget figures for the completed period
+     */
+    public void sendBudgetGroupSuccessEmail(
+            final String toEmail,
+            final String userName,
+            final String walletName,
+            final BudgetResponse budget
+    ) {
+        Context context = new Context();
+        context.setVariable("userName", userName);
+        context.setVariable("walletName", walletName);
+        context.setVariable("budgetLimit", budget.getBudgetLimit());
+        context.setVariable("spent", budget.getSpent());
+        context.setVariable("percentage", budget.getPercentage());
+        context.setVariable("manageUrl",
+                frontendUrl.replaceAll("/+$", "") + "/budgets");
+        context.setVariable("year", Year.now().getValue());
+        context.setVariable("supportEmail", supportEmail);
+        context.setVariable("logoUrl", logoUrl);
+
+        String html = templateEngine.process(
+                "budget-group-success", context);
+
+        sesEmailService.sendEmail(
+                toEmail,
+                walletName + " stayed within budget \uD83C\uDF89",
+                html
+        );
     }
 }

--- a/src/main/java/bflow/contact/controllers/ContactController.java
+++ b/src/main/java/bflow/contact/controllers/ContactController.java
@@ -1,0 +1,28 @@
+package bflow.contact.controllers;
+
+import bflow.contact.dto.ContactRequest;
+import bflow.contact.service.ContactService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/contact")
+@RequiredArgsConstructor
+public class ContactController {
+
+    private final ContactService contactService;
+
+    @PostMapping
+    public ResponseEntity<Void> sendMessage(
+            @Valid @RequestBody ContactRequest request
+    ) {
+        contactService.sendMessage(request);
+
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/src/main/java/bflow/contact/dto/ContactRequest.java
+++ b/src/main/java/bflow/contact/dto/ContactRequest.java
@@ -1,0 +1,25 @@
+package bflow.contact.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ContactRequest(
+        @NotBlank
+        @Size(max = 100)
+        String name,
+
+        @NotBlank
+        @Email
+        @Size(max = 254)
+        String email,
+
+        @NotBlank
+        @Size(max = 150)
+        String subject,
+
+        @NotBlank
+        @Size(max = 5000)
+        String message
+) {
+}

--- a/src/main/java/bflow/contact/service/ContactService.java
+++ b/src/main/java/bflow/contact/service/ContactService.java
@@ -1,0 +1,32 @@
+package bflow.contact.service;
+
+import bflow.common.aws.service.EmailTemplateService;
+import bflow.contact.dto.ContactRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ContactService {
+
+    /**
+     * Service responsible for sending templated emails.
+     */
+    private final EmailTemplateService emailTemplateService;
+
+    /**
+     * Sends a contact message to the configured BFlow support address.
+     *
+     * @param request contact form request
+     */
+    public void sendMessage(final ContactRequest request) {
+        emailTemplateService.sendContactMessage(
+                request.name(),
+                request.email(),
+                request.subject(),
+                request.message()
+        );
+    }
+}

--- a/src/main/java/bflow/dashboard/dto/BudgetHealthItem.java
+++ b/src/main/java/bflow/dashboard/dto/BudgetHealthItem.java
@@ -1,6 +1,7 @@
 package bflow.dashboard.dto;
 
 import bflow.budget.enums.BudgetStatus;
+import bflow.wallet.enums.Currency;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -9,5 +10,6 @@ public record BudgetHealthItem(
         UUID id,
         String displayName,
         Instant updatedAt,
-        BudgetStatus status
+        BudgetStatus status,
+        Currency currency
 ) { }

--- a/src/main/java/bflow/dashboard/service/ServiceDashboard.java
+++ b/src/main/java/bflow/dashboard/service/ServiceDashboard.java
@@ -408,7 +408,8 @@ public class ServiceDashboard {
                         budget.getId(),
                         resolveDisplayName(budget),
                         budget.getUpdatedAt(),
-                        budget.getLastAlertStatus()
+                        budget.getLastAlertStatus(),
+                        budget.getCurrency()
                 ))
                 .toList();
     }

--- a/src/main/java/bflow/expenses/services/QuickExpenseService.java
+++ b/src/main/java/bflow/expenses/services/QuickExpenseService.java
@@ -1,7 +1,9 @@
 package bflow.expenses.services;
 
+import bflow.auth.services.UserService;
 import bflow.budget.services.BudgetService;
 import bflow.category.entity.Category;
+import bflow.common.exception.ResourceNotFoundException;
 import bflow.expenses.DTO.QuickExpenseRequest;
 import bflow.expenses.DTO.ExpenseResponse;
 import bflow.expenses.RepositoryExpense;
@@ -10,10 +12,14 @@ import bflow.merchant.MerchantDetectionService;
 import bflow.wallet.entities.Wallet;
 import bflow.wallet.entities.WalletUser;
 import bflow.wallet.enums.WalletRole;
+import bflow.wallet.repository.RepositoryWallet;
 import bflow.wallet.repository.RepositoryWalletUser;
+import bflow.wallet.service.ServiceWallet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -39,6 +45,22 @@ public class QuickExpenseService {
      * Repository for expense operations.
      */
     private final RepositoryExpense repositoryExpense;
+
+    /**
+     * Repository for wallet operations, used to acquire a pessimistic
+     * lock on the target wallet before mutating its balance.
+     */
+    private final RepositoryWallet repositoryWallet;
+
+    /**
+     * Service encapsulating wallet balance mutations.
+     */
+    private final ServiceWallet serviceWallet;
+
+    /**
+     * Service for user business logic operations.
+     */
+    private final UserService userService;
 
     /**
      * Service for merchant category detection.
@@ -67,13 +89,25 @@ public class QuickExpenseService {
             final UUID userId,
             final QuickExpenseRequest request
     ) {
+        userService.validateUserActive(userId);
+
         WalletUser walletUser = walletUserRepository
             .findFirstByUserIdAndRole(userId, WalletRole.OWNER)
             .orElseThrow(() ->
                 new RuntimeException("No wallet found")
         );
 
-        Wallet wallet = walletUser.getWallet();
+        // Lock the wallet row for the duration of this transaction so
+        // the balance read-modify-write below can't race with a
+        // concurrent expense/income/transfer touching the same wallet.
+        Wallet wallet = repositoryWallet
+                .findByIdForUpdate(walletUser.getWallet().getId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Wallet not found"
+                ));
+
+        BigDecimal amount =
+                request.getAmount().setScale(2, RoundingMode.HALF_EVEN);
 
         String normalized = normalize(request.getDescription());
 
@@ -81,7 +115,7 @@ public class QuickExpenseService {
 
         Expense expense = new Expense();
 
-        expense.setAmount(request.getAmount());
+        expense.setAmount(amount);
         expense.setDescription(request.getDescription());
         expense.setTitle(generateTitle(request.getDescription()));
         expense.setDate(LocalDate.now());
@@ -99,6 +133,13 @@ public class QuickExpenseService {
         expense.setRecurring(false);
         expense.setTaxDeductible(false);
         expense.setReimbursable(false);
+
+        // Fix for both balance-duplication exploits: without this
+        // line the wallet balance was never debited on creation, so a
+        // later PUT/DELETE on this same expense via ControllerExpense
+        // would credit the balance for an amount that was never
+        // subtracted in the first place.
+        serviceWallet.subtractBalance(wallet, amount);
 
         Expense saved = repositoryExpense.save(expense);
 

--- a/src/main/java/bflow/notifications/enums/NotificationType.java
+++ b/src/main/java/bflow/notifications/enums/NotificationType.java
@@ -9,6 +9,11 @@ public enum NotificationType {
      */
     BUDGET_SUCCESS,
     /**
+     * Group budget success notification, sent to every member of a
+     * shared wallet when the wallet stays within budget as a team.
+     */
+    BUDGET_GROUP_SUCCESS,
+    /**
      * Budget warning notification.
      */
     BUDGET_WARNING,

--- a/src/main/java/bflow/notifications/service/NotificationService.java
+++ b/src/main/java/bflow/notifications/service/NotificationService.java
@@ -1,7 +1,9 @@
 package bflow.notifications.service;
 
+import bflow.auth.entities.User;
 import bflow.auth.repository.RepositoryUser;
 import bflow.budget.DTO.BudgetResponse;
+import bflow.common.aws.service.EmailTemplateService;
 import bflow.common.aws.service.SesEmailService;
 import bflow.notifications.DTO.NotificationResponse;
 import bflow.notifications.entity.Notification;
@@ -30,6 +32,11 @@ public final class NotificationService {
      * Repository for user operations.
      */
     private final RepositoryUser repositoryUser;
+
+    /**
+     * Service for sending Thymeleaf-templated emails.
+     */
+    private final EmailTemplateService emailTemplateService;
 
     /**
      * Send a warning notification about budget usage.
@@ -189,6 +196,40 @@ public final class NotificationService {
         );
 
         sendEmail(userId, "Budget Completed", message);
+    }
+
+    /**
+     * Send a group celebration notification to every member of a
+     * shared wallet when the wallet stays within budget as a team
+     * for the completed period. Each member gets both an in-app
+     * notification and a Thymeleaf-templated email addressed to
+     * them personally.
+     *
+     * @param members every member of the wallet (including the
+     *         budget's owner)
+     * @param walletName the shared wallet's display name
+     * @param budget the final budget figures for the period
+     */
+    public void sendBudgetGroupSuccess(
+            final List<User> members,
+            final String walletName,
+            final BudgetResponse budget
+    ) {
+        for (User member : members) {
+            create(
+                    member.getId(),
+                    NotificationType.BUDGET_GROUP_SUCCESS,
+                    "Team budget completed!",
+                    walletName + " stayed within budget this period \uD83C\uDF89"
+            );
+
+            emailTemplateService.sendBudgetGroupSuccessEmail(
+                    member.getEmail(),
+                    member.getName(),
+                    walletName,
+                    budget
+            );
+        }
     }
 
     /**

--- a/src/main/java/bflow/subscription/services/SubscriptionService.java
+++ b/src/main/java/bflow/subscription/services/SubscriptionService.java
@@ -10,6 +10,7 @@ import bflow.subscription.repository.RepositorySubscription;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -131,23 +132,33 @@ public class SubscriptionService {
      */
     @Transactional
     public void createFreeSubscription(final User user) {
-
-        repositorySubscription
+        boolean hasActiveSubscription = repositorySubscription
                 .findByUserIdAndStatus(user.getId(), SubscriptionStatus.ACTIVE)
-                .filter(s -> s.getPlan().getCode().equals("FREE"))
-                .orElseGet(() -> {
-                    Plan freePlan = planService.getFreePlan();
+                .isPresent();
 
-                    Subscription subscription = new Subscription();
-                    subscription.setUser(user);
-                    subscription.setPlan(freePlan);
-                    subscription.setStatus(SubscriptionStatus.ACTIVE);
-                    subscription.setBillingAmount(freePlan.getPrice());
-                    subscription.setStartsAt(Instant.now());
-                    subscription.setAutoRenew(false);
+        if (hasActiveSubscription) {
+            return;
+        }
 
-                    return repositorySubscription.save(subscription);
-                });
+        Plan freePlan = planService.getFreePlan();
+
+        Subscription subscription = new Subscription();
+        subscription.setUser(user);
+        subscription.setPlan(freePlan);
+        subscription.setStatus(SubscriptionStatus.ACTIVE);
+        subscription.setBillingAmount(freePlan.getPrice());
+        subscription.setStartsAt(Instant.now());
+        subscription.setAutoRenew(false);
+
+        try {
+            repositorySubscription.save(subscription);
+        } catch (DataIntegrityViolationException ex) {
+            log.debug(
+                    "Concurrent bootstrap detected for user {}, "
+                            + "FREE plan creation will be omitted.",
+                    user.getId()
+            );
+        }
     }
 }
 

--- a/src/main/java/bflow/wallet/controllers/ControllerWalletInvitation.java
+++ b/src/main/java/bflow/wallet/controllers/ControllerWalletInvitation.java
@@ -322,6 +322,42 @@ public class ControllerWalletInvitation {
     }
 
     /**
+     * Leaves a shared wallet. The authenticated user removes
+     * themselves — the self-service counterpart to
+     * {@link #removeMember}, which only the owner can invoke on
+     * someone else. The owner cannot leave this way; they must
+     * transfer ownership or delete the wallet instead.
+     *
+     * @param walletId the wallet UUID
+     * @param authentication the authenticated user
+     * @param httpRequest the current HTTP request
+     * @return a successful response
+     */
+    @Operation(
+            summary = "Leaves a shared wallet.",
+            description = "Removes the authenticated user from the specified wallet. "
+                    + "The wallet owner cannot leave this way — ownership must be "
+                    + "transferred, or the wallet deleted, instead."
+    )
+    @DeleteMapping("/{walletId}/members/me")
+    public ApiResponse<Void> leaveWallet(
+            @PathVariable final UUID walletId,
+            final Authentication authentication,
+            final HttpServletRequest httpRequest
+    ) {
+
+        UUID userId = currentUserService.getCurrentUserId(authentication);
+
+        serviceWalletSharing.leaveWallet(walletId, userId);
+
+        return ApiResponse.success(
+                "You have left the wallet.",
+                null,
+                httpRequest.getRequestURI()
+        );
+    }
+
+    /**
      * Retrieves all pending invitations for the authenticated user.
      *
      * @param authentication the authenticated user

--- a/src/main/java/bflow/wallet/repository/RepositoryWalletUser.java
+++ b/src/main/java/bflow/wallet/repository/RepositoryWalletUser.java
@@ -106,6 +106,16 @@ public interface RepositoryWalletUser extends JpaRepository<WalletUser, UUID>,
     List<UUID> findWalletIdsByUserId(UUID userId);
 
     /**
+     * Finds every wallet-user relationship for a given user, across
+     * all wallets they belong to. Used to build the "my wallets"
+     * list on login/session sync.
+     *
+     * @param userId the user UUID
+     * @return the user's wallet memberships
+     */
+    List<WalletUser> findByUserId(UUID userId);
+
+    /**
      * Retrieves the identifiers of all wallets associated with a
      * user, filtered to a specific currency. Used by CATEGORY_GLOBAL
      * budgets so spend is only summed across wallets denominated in

--- a/src/main/java/bflow/wallet/service/ServiceWalletSharing.java
+++ b/src/main/java/bflow/wallet/service/ServiceWalletSharing.java
@@ -628,6 +628,40 @@ public class ServiceWalletSharing {
     }
 
     /**
+     * Leaves a shared wallet — the self-service counterpart to
+     * {@link #removeMember}, which only the owner can invoke on
+     * someone else.
+     *
+     * The owner cannot leave through this method: a wallet with no
+     * owner would leave every remaining member without anyone able
+     * to invite, remove members, or otherwise administer it.
+     *
+     * @param walletId the wallet UUID
+     * @param userId the user leaving the wallet
+     */
+    public void leaveWallet(
+            final UUID walletId,
+            final UUID userId
+    ) {
+
+        WalletUser member = repositoryWalletUser
+                .findByWalletIdAndUserId(walletId, userId)
+                .orElseThrow(() ->
+                        new NotFoundException(
+                                "You are not a member of this wallet."
+                        ));
+
+        if (member.getRole() == WalletRole.OWNER) {
+            throw new ConflictException(
+                    "The wallet owner cannot leave. Transfer ownership "
+                            + "or delete the wallet instead."
+            );
+        }
+
+        repositoryWalletUser.delete(member);
+    }
+
+    /**
      * Retrieves all pending wallet invitations for the specified user.
      *
      * Only invitations that have not expired are returned.

--- a/src/main/resources/db/migration/V26__enforce_single_active_subscription_per_user.sql
+++ b/src/main/resources/db/migration/V26__enforce_single_active_subscription_per_user.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX idx_unique_active_subscription_per_user
+ON subscriptions (user_id)
+WHERE status = 'ACTIVE';

--- a/src/main/resources/db/migration/V27__add_name_source_to_users.sql
+++ b/src/main/resources/db/migration/V27__add_name_source_to_users.sql
@@ -1,0 +1,7 @@
+ALTER TABLE users
+    ADD COLUMN name_source VARCHAR(20) NOT NULL DEFAULT 'GOOGLE';
+
+-- Users who already have a name diverging from what Google would send
+-- can't be distinguished retroactively without an audit trail, so every
+-- existing row defaults to GOOGLE (sync can overwrite). Only names set
+-- from this point forward via PATCH /me will be protected.

--- a/src/main/resources/templates/budget-group-success.html
+++ b/src/main/resources/templates/budget-group-success.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <title>Your team stayed within budget</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <!-- Poppins -->
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
+    </style>
+
+    <!-- Preheader -->
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;">
+        [[${walletName}]] stayed within budget this period — nice work, team.
+    </div>
+</head>
+
+<body style="
+    margin:0;
+    padding:0;
+    background-color:#0F1217;
+    background-image:linear-gradient(180deg,#0F1217 0%,#1A1F26 100%);
+    -webkit-text-size-adjust:100%;
+    -ms-text-size-adjust:100%;
+">
+
+<table
+        role="presentation"
+        width="100%"
+        style="
+            width:100%;
+            background-color:#0F1217;
+            background-image:linear-gradient(180deg,#0F1217 0%,#1A1F26 100%);
+        "
+>
+    <tr>
+        <td align="center" style="padding:40px 16px;">
+
+            <!-- Main Container -->
+            <table
+                    role="presentation"
+                    width="600"
+                    style="
+                        width:100%;
+                        max-width:600px;
+                        border-radius:24px;
+                        overflow:hidden;
+                        border:3px solid #262A31;
+                        background-color:#1A1F26;
+                    "
+            >
+                <tr>
+                    <td style="padding:40px;">
+
+                        <!-- Header -->
+                        <table role="presentation" width="100%">
+                            <tr>
+
+                                <td align="left" valign="middle">
+
+                                    <h1 style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:28px;
+                                        line-height:36px;
+                                        color:#FFFFFF;
+                                        font-weight:600;
+                                        letter-spacing:-0.5px;
+                                    ">
+                                        Budget goal, completed
+                                    </h1>
+
+                                    <table role="presentation" style="margin-top:12px;">
+                                        <tr>
+                                            <td
+                                                    width="48"
+                                                    height="4"
+                                                    bgcolor="#2FBF71"
+                                                    style="
+                                                        border-radius:999px;
+                                                        font-size:1px;
+                                                        line-height:1px;
+                                                    "
+                                            >
+                                                &nbsp;
+                                            </td>
+                                        </tr>
+                                    </table>
+
+                                </td>
+
+                                <td align="right" valign="middle" width="90">
+
+                                    <img
+                                            th:src="${logoUrl}"
+                                            alt="BFlow"
+                                            width="78"
+                                            style="
+                                                display:block;
+                                                border:0;
+                                                outline:none;
+                                                text-decoration:none;
+                                            "
+                                    />
+
+                                </td>
+
+                            </tr>
+                        </table>
+
+                        <!-- Greeting -->
+                        <table role="presentation" width="100%" style="margin-top:36px;">
+                            <tr>
+                                <td>
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:15px;
+                                        line-height:24px;
+                                        color:#A4A9B3;
+                                    ">
+                                        Hello
+                                        <strong style="color:#FFFFFF;font-weight:600;">
+                                            [[${userName}]]
+                                        </strong>
+                                    </p>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Content -->
+                        <table role="presentation" width="100%" style="margin-top:20px;">
+                            <tr>
+                                <td>
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:15px;
+                                        line-height:24px;
+                                        color:#A4A9B3;
+                                    ">
+                                        Great teamwork — the shared wallet
+                                        <strong style="color:#FFFFFF;font-weight:600;">
+                                            "[[${walletName}]]"
+                                        </strong>
+                                        stayed within budget this period. Everyone who
+                                        contributed to this wallet helped make it happen.
+                                    </p>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Stats box -->
+                        <table
+                                role="presentation"
+                                width="100%"
+                                style="
+                                    margin-top:28px;
+                                    background-color:#13161C;
+                                    border:1px solid #262A31;
+                                    border-radius:14px;
+                                "
+                        >
+                            <tr>
+                                <td style="padding:20px;">
+
+                                    <table role="presentation" width="100%">
+                                        <tr>
+                                            <td>
+                                                <p style="
+                                                    margin:0;
+                                                    font-family:'Poppins',Arial,sans-serif;
+                                                    font-size:12px;
+                                                    line-height:18px;
+                                                    color:#737883;
+                                                    text-transform:uppercase;
+                                                    letter-spacing:0.5px;
+                                                ">
+                                                    Spent
+                                                </p>
+                                                <p style="
+                                                    margin:4px 0 0 0;
+                                                    font-family:'Poppins',Arial,sans-serif;
+                                                    font-size:18px;
+                                                    line-height:24px;
+                                                    color:#FFFFFF;
+                                                    font-weight:600;
+                                                ">
+                                                    $[[${spent}]]
+                                                </p>
+                                            </td>
+                                            <td>
+                                                <p style="
+                                                    margin:0;
+                                                    font-family:'Poppins',Arial,sans-serif;
+                                                    font-size:12px;
+                                                    line-height:18px;
+                                                    color:#737883;
+                                                    text-transform:uppercase;
+                                                    letter-spacing:0.5px;
+                                                ">
+                                                    Budget
+                                                </p>
+                                                <p style="
+                                                    margin:4px 0 0 0;
+                                                    font-family:'Poppins',Arial,sans-serif;
+                                                    font-size:18px;
+                                                    line-height:24px;
+                                                    color:#FFFFFF;
+                                                    font-weight:600;
+                                                ">
+                                                    $[[${budgetLimit}]]
+                                                </p>
+                                            </td>
+                                            <td>
+                                                <p style="
+                                                    margin:0;
+                                                    font-family:'Poppins',Arial,sans-serif;
+                                                    font-size:12px;
+                                                    line-height:18px;
+                                                    color:#737883;
+                                                    text-transform:uppercase;
+                                                    letter-spacing:0.5px;
+                                                ">
+                                                    Used
+                                                </p>
+                                                <p style="
+                                                    margin:4px 0 0 0;
+                                                    font-family:'Poppins',Arial,sans-serif;
+                                                    font-size:18px;
+                                                    line-height:24px;
+                                                    color:#2FBF71;
+                                                    font-weight:600;
+                                                ">
+                                                    [[${percentage}]]%
+                                                </p>
+                                            </td>
+                                        </tr>
+                                    </table>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- CTA -->
+                        <table role="presentation" width="100%" style="margin-top:32px;">
+                            <tr>
+                                <td align="center">
+
+                                    <a
+                                            th:href="${manageUrl}"
+                                            target="_blank"
+                                            style="
+                                                display:block;
+                                                width:100%;
+                                                box-sizing:border-box;
+                                                background-color:#F46A12;
+                                                color:#FFFFFF;
+                                                text-decoration:none;
+                                                font-family:'Poppins',Arial,sans-serif;
+                                                font-size:16px;
+                                                font-weight:600;
+                                                text-align:center;
+                                                padding:16px 24px;
+                                                border-radius:12px;
+                                                box-shadow:0 4px 14px rgba(244,106,18,0.20);
+                                            "
+                                    >
+                                        View wallet budgets
+                                    </a>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Divider -->
+                        <table role="presentation" width="100%" style="margin-top:32px;">
+                            <tr>
+                                <td style="border-top:1px solid #262A31;"></td>
+                            </tr>
+                        </table>
+
+                        <!-- Footer -->
+                        <table role="presentation" width="100%" style="margin-top:24px;">
+                            <tr>
+                                <td>
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:12px;
+                                        line-height:20px;
+                                        color:#636873;
+                                    ">
+                                        © [[${year}]] BFlow Studio.
+                                        Financial clarity starts with visibility.
+                                    </p>
+
+                                    <p style="
+                                        margin:8px 0 0 0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:12px;
+                                        line-height:20px;
+                                        color:#636873;
+                                    ">
+                                        Need help?
+
+                                        <a
+                                                th:href="'mailto:' + ${supportEmail}"
+                                                style="
+                                                    color:#F38533;
+                                                    text-decoration:none;
+                                                "
+                                        >
+                                            [[${supportEmail}]]
+                                        </a>
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/contact-message.html
+++ b/src/main/resources/templates/contact-message.html
@@ -1,0 +1,426 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>New contact message</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <!-- Poppins -->
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
+    </style>
+
+    <!-- Preheader -->
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;">
+        New contact message from [[${senderName}]]: [[${subject}]]
+    </div>
+</head>
+
+<body style="
+    margin:0;
+    padding:0;
+    background-color:#0F1217;
+    background-image:linear-gradient(180deg,#0F1217 0%,#1A1F26 100%);
+    -webkit-text-size-adjust:100%;
+    -ms-text-size-adjust:100%;
+">
+
+<table
+        role="presentation"
+        width="100%"
+        style="
+            width:100%;
+            background-color:#0F1217;
+            background-image:linear-gradient(180deg,#0F1217 0%,#1A1F26 100%);
+        "
+>
+    <tr>
+        <td align="center" style="padding:40px 16px;">
+
+            <!-- Main Container -->
+            <table
+                    role="presentation"
+                    width="600"
+                    style="
+                        width:100%;
+                        max-width:600px;
+                        border-radius:24px;
+                        overflow:hidden;
+                        border:3px solid #262A31;
+                        background-color:#1A1F26;
+                    "
+            >
+                <tr>
+                    <td style="padding:40px;">
+
+                        <!-- Header -->
+                        <table role="presentation" width="100%">
+                            <tr>
+
+                                <td align="left" valign="middle">
+
+                                    <h1 style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:30px;
+                                        line-height:40px;
+                                        color:#FFFFFF;
+                                        font-weight:600;
+                                        letter-spacing:-0.5px;
+                                    ">
+                                        New contact message
+                                    </h1>
+
+                                    <table role="presentation" style="margin-top:12px;">
+                                        <tr>
+                                            <td
+                                                    width="48"
+                                                    height="4"
+                                                    bgcolor="#F46A12"
+                                                    style="
+                                                        border-radius:999px;
+                                                        font-size:1px;
+                                                        line-height:1px;
+                                                    "
+                                            >
+                                                &nbsp;
+                                            </td>
+                                        </tr>
+                                    </table>
+
+                                </td>
+
+                                <td align="right" valign="middle" width="90">
+
+                                    <img
+                                            th:src="${logoUrl}"
+                                            alt="BFlow"
+                                            width="78"
+                                            style="
+                                                display:block;
+                                                border:0;
+                                                outline:none;
+                                                text-decoration:none;
+                                            "
+                                    />
+
+                                </td>
+
+                            </tr>
+                        </table>
+
+                        <!-- Introduction -->
+                        <table role="presentation" width="100%" style="margin-top:36px;">
+                            <tr>
+                                <td>
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:15px;
+                                        line-height:24px;
+                                        color:#A4A9B3;
+                                    ">
+                                        A new message has been submitted through the
+                                        <strong style="color:#FFFFFF;font-weight:600;">
+                                            BFlow
+                                        </strong>
+                                        contact form.
+                                    </p>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Sender Information -->
+                        <table
+                                role="presentation"
+                                width="100%"
+                                style="
+                                    margin-top:28px;
+                                    background-color:#13161C;
+                                    border:1px solid #262A31;
+                                    border-radius:14px;
+                                "
+                        >
+                            <tr>
+                                <td style="padding:20px;">
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:14px;
+                                        line-height:20px;
+                                        color:#FFFFFF;
+                                        font-weight:600;
+                                    ">
+                                        Contact details
+                                    </p>
+
+                                    <table
+                                            role="presentation"
+                                            width="100%"
+                                            style="margin-top:12px;"
+                                    >
+                                        <tr>
+                                            <td style="
+                                                font-family:'Poppins',Arial,sans-serif;
+                                                font-size:13px;
+                                                line-height:22px;
+                                                color:#737883;
+                                            ">
+                                                Name
+                                            </td>
+
+                                            <td
+                                                    align="right"
+                                                    style="
+                                                        font-family:'Poppins',Arial,sans-serif;
+                                                        font-size:13px;
+                                                        line-height:22px;
+                                                        color:#FFFFFF;
+                                                        font-weight:600;
+                                                    "
+                                            >
+                                                [[${senderName}]]
+                                            </td>
+                                        </tr>
+
+                                        <tr>
+                                            <td style="
+                                                font-family:'Poppins',Arial,sans-serif;
+                                                font-size:13px;
+                                                line-height:22px;
+                                                color:#737883;
+                                            ">
+                                                Email
+                                            </td>
+
+                                            <td
+                                                    align="right"
+                                                    style="
+                                                        font-family:'Poppins',Arial,sans-serif;
+                                                        font-size:13px;
+                                                        line-height:22px;
+                                                        color:#FFFFFF;
+                                                        font-weight:600;
+                                                    "
+                                            >
+                                                <a
+                                                        th:href="'mailto:' + ${senderEmail}"
+                                                        style="
+                                                            color:#F38533;
+                                                            text-decoration:none;
+                                                        "
+                                                >
+                                                    [[${senderEmail}]]
+                                                </a>
+                                            </td>
+                                        </tr>
+
+                                        <tr>
+                                            <td style="
+                                                font-family:'Poppins',Arial,sans-serif;
+                                                font-size:13px;
+                                                line-height:22px;
+                                                color:#737883;
+                                            ">
+                                                Subject
+                                            </td>
+
+                                            <td
+                                                    align="right"
+                                                    style="
+                                                        font-family:'Poppins',Arial,sans-serif;
+                                                        font-size:13px;
+                                                        line-height:22px;
+                                                        color:#FFFFFF;
+                                                        font-weight:600;
+                                                    "
+                                            >
+                                                [[${subject}]]
+                                            </td>
+                                        </tr>
+                                    </table>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Message -->
+                        <table
+                                role="presentation"
+                                width="100%"
+                                style="
+                                    margin-top:28px;
+                                    background-color:#13161C;
+                                    border:1px solid #262A31;
+                                    border-radius:14px;
+                                "
+                        >
+                            <tr>
+                                <td style="padding:20px;">
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:14px;
+                                        line-height:20px;
+                                        color:#FFFFFF;
+                                        font-weight:600;
+                                    ">
+                                        Message
+                                    </p>
+
+                                    <table
+                                            role="presentation"
+                                            width="100%"
+                                            style="
+                                                margin-top:16px;
+                                                background-color:#1A1F26;
+                                                border-left:3px solid #F46A12;
+                                            "
+                                    >
+                                        <tr>
+                                            <td style="padding:16px 18px;">
+
+                                                <p
+                                                        th:text="${message}"
+                                                        style="
+                                                            margin:0;
+                                                            font-family:'Poppins',Arial,sans-serif;
+                                                            font-size:14px;
+                                                            line-height:24px;
+                                                            color:#A4A9B3;
+                                                            white-space:pre-line;
+                                                        "
+                                                >
+                                                    Message content
+                                                </p>
+
+                                            </td>
+                                        </tr>
+                                    </table>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Reply CTA -->
+                        <table
+                                role="presentation"
+                                width="100%"
+                                style="margin-top:32px;"
+                        >
+                            <tr>
+                                <td align="center">
+
+                                    <a
+                                            th:href="'mailto:' + ${senderEmail}"
+                                            target="_blank"
+                                            style="
+                                                display:block;
+                                                width:100%;
+                                                box-sizing:border-box;
+                                                background-color:#F46A12;
+                                                color:#FFFFFF;
+                                                text-decoration:none;
+                                                font-family:'Poppins',Arial,sans-serif;
+                                                font-size:16px;
+                                                font-weight:600;
+                                                text-align:center;
+                                                padding:16px 24px;
+                                                border-radius:12px;
+                                                box-shadow:0 4px 14px rgba(244,106,18,0.20);
+                                            "
+                                    >
+                                        Reply to [[${senderName}]]
+                                    </a>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Reply Information -->
+                        <table
+                                role="presentation"
+                                width="100%"
+                                style="margin-top:28px;"
+                        >
+                            <tr>
+                                <td>
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:13px;
+                                        line-height:20px;
+                                        color:#636873;
+                                    ">
+                                        You can reply directly to this email to contact
+                                        <strong style="color:#A4A9B3;font-weight:500;">
+                                            [[${senderName}]]
+                                        </strong>
+                                        at
+                                        <a
+                                                th:href="'mailto:' + ${senderEmail}"
+                                                style="
+                                                    color:#F38533;
+                                                    text-decoration:none;
+                                                "
+                                        >
+                                            [[${senderEmail}]]
+                                        </a>.
+                                    </p>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Divider -->
+                        <table role="presentation" width="100%" style="margin-top:32px;">
+                            <tr>
+                                <td style="border-top:1px solid #262A31;"></td>
+                            </tr>
+                        </table>
+
+                        <!-- Footer -->
+                        <table role="presentation" width="100%" style="margin-top:24px;">
+                            <tr>
+                                <td>
+
+                                    <p style="
+                                        margin:0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:12px;
+                                        line-height:20px;
+                                        color:#636873;
+                                    ">
+                                        © [[${year}]] BFlow Studio.
+                                        Financial clarity starts with visibility.
+                                    </p>
+
+                                    <p style="
+                                        margin:8px 0 0 0;
+                                        font-family:'Poppins',Arial,sans-serif;
+                                        font-size:12px;
+                                        line-height:20px;
+                                        color:#636873;
+                                    ">
+                                        This message was generated from the BFlow contact form.
+                                    </p>
+
+                                </td>
+                            </tr>
+                        </table>
+
+                    </td>
+                </tr>
+            </table>
+
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>

--- a/src/test/java/Diaz/Dev/BFlow/budget/services/BudgetServiceGroupSuccessTest.java
+++ b/src/test/java/Diaz/Dev/BFlow/budget/services/BudgetServiceGroupSuccessTest.java
@@ -1,0 +1,228 @@
+package Diaz.Dev.BFlow.budget.services;
+
+import bflow.auth.entities.User;
+import bflow.auth.services.UserService;
+import bflow.budget.DTO.BudgetResponse;
+import bflow.budget.entity.Budget;
+import bflow.budget.enums.BudgetScope;
+import bflow.budget.enums.BudgetStatus;
+import bflow.budget.enums.PeriodType;
+import bflow.budget.repository.RepositoryBudget;
+import bflow.budget.services.BudgetAlertService;
+import bflow.budget.services.BudgetCalculationService;
+import bflow.budget.services.BudgetLifecycleService;
+import bflow.budget.services.BudgetOverlapValidationService;
+import bflow.budget.services.BudgetService;
+import bflow.budget.services.BudgetValidationService;
+import bflow.expenses.RepositoryExpense;
+import bflow.notifications.service.NotificationService;
+import bflow.subscription.services.PlanLimitService;
+import bflow.wallet.entities.Wallet;
+import bflow.wallet.entities.WalletUser;
+import bflow.wallet.enums.Currency;
+import bflow.wallet.enums.WalletRole;
+import bflow.wallet.repository.RepositoryWalletUser;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the group-budget-celebration behavior added to
+ * {@link BudgetService#evaluateBudgetsForWallet(UUID)}: a completed,
+ * non-exceeded period on a shared wallet should notify every member
+ * of that wallet, not just the budget's owner.
+ */
+@ExtendWith(MockitoExtension.class)
+class BudgetServiceGroupSuccessTest {
+
+    @Mock
+    private RepositoryBudget repositoryBudget;
+
+    @Mock
+    private BudgetCalculationService calculationService;
+
+    @Mock
+    private BudgetAlertService alertService;
+
+    @Mock
+    private RepositoryWalletUser repositoryWalletUser;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private BudgetValidationService validationService;
+
+    @Mock
+    private BudgetLifecycleService lifecycleService;
+
+    @Mock
+    private BudgetOverlapValidationService overlapValidationService;
+
+    @Mock
+    private PlanLimitService planLimitService;
+
+    @Mock
+    private RepositoryExpense repositoryExpense;
+
+    @Mock
+    private EntityManager entityManager;
+
+    private BudgetService budgetService;
+
+    private UUID walletId;
+    private Wallet wallet;
+    private User owner;
+    private Budget budget;
+
+    @BeforeEach
+    void setUp() {
+        budgetService = new BudgetService(
+                repositoryBudget,
+                calculationService,
+                alertService,
+                repositoryWalletUser,
+                userService,
+                notificationService,
+                validationService,
+                lifecycleService,
+                overlapValidationService,
+                planLimitService,
+                repositoryExpense,
+                entityManager
+        );
+
+        walletId = UUID.randomUUID();
+
+        wallet = new Wallet();
+        wallet.setId(walletId);
+        wallet.setName("Household");
+        wallet.setCurrency(Currency.USD);
+
+        owner = new User();
+        owner.setId(UUID.randomUUID());
+        owner.setEmail("owner@example.com");
+        owner.setName("Owner");
+
+        budget = new Budget();
+        budget.setId(UUID.randomUUID());
+        budget.setUser(owner);
+        budget.setWallet(wallet);
+        budget.setScope(BudgetScope.WALLET);
+        budget.setPeriod(PeriodType.MONTHLY);
+        budget.setAmount(BigDecimal.valueOf(500));
+        budget.setStartDate(LocalDate.now().minusMonths(1));
+
+        // Period has already ended as of "today".
+        lenient().when(lifecycleService.calculateEndDate(budget))
+                .thenReturn(LocalDate.now().minusDays(1));
+        lenient().when(repositoryBudget.findByWalletId(walletId))
+                .thenReturn(List.of(budget));
+    }
+
+    private WalletUser memberOf(final Wallet w, final WalletRole role) {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setEmail(UUID.randomUUID() + "@example.com");
+        user.setName("Member");
+
+        WalletUser wu = new WalletUser();
+        wu.setWallet(w);
+        wu.setUser(user);
+        wu.setRole(role);
+        return wu;
+    }
+
+    @Test
+    void evaluateBudgetsForWallet_multiMemberWallet_notEnded_sendsGroupSuccess() {
+        BudgetResponse okResponse = new BudgetResponse();
+        okResponse.setStatus(BudgetStatus.OK);
+        when(calculationService.calculate(budget)).thenReturn(okResponse);
+
+        WalletUser ownerLink = memberOf(wallet, WalletRole.OWNER);
+        ownerLink.setUser(owner);
+        WalletUser memberLink = memberOf(wallet, WalletRole.MEMBER);
+
+        when(repositoryWalletUser.findByWalletId(walletId))
+                .thenReturn(List.of(ownerLink, memberLink));
+
+        budgetService.evaluateBudgetsForWallet(walletId);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<User>> membersCaptor =
+                ArgumentCaptor.forClass(List.class);
+
+        verify(notificationService).sendBudgetGroupSuccess(
+                membersCaptor.capture(), eq("Household"), eq(okResponse));
+
+        assertEquals(2, membersCaptor.getValue().size());
+        assertTrue(membersCaptor.getValue().contains(owner));
+
+        verify(notificationService, never())
+                .sendBudgetSuccess(any(), any());
+    }
+
+    @Test
+    void evaluateBudgetsForWallet_singleMemberWallet_sendsPersonalSuccess() {
+        BudgetResponse okResponse = new BudgetResponse();
+        okResponse.setStatus(BudgetStatus.OK);
+        when(calculationService.calculate(budget)).thenReturn(okResponse);
+
+        WalletUser ownerLink = memberOf(wallet, WalletRole.OWNER);
+        ownerLink.setUser(owner);
+
+        when(repositoryWalletUser.findByWalletId(walletId))
+                .thenReturn(List.of(ownerLink));
+
+        budgetService.evaluateBudgetsForWallet(walletId);
+
+        verify(notificationService)
+                .sendBudgetSuccess(owner.getId(), okResponse);
+        verify(notificationService, never())
+                .sendBudgetGroupSuccess(any(), any(), any());
+    }
+
+    @Test
+    void evaluateBudgetsForWallet_budgetExceeded_sendsNoSuccessNotification() {
+        BudgetResponse exceededResponse = new BudgetResponse();
+        exceededResponse.setStatus(BudgetStatus.EXCEEDED);
+        when(calculationService.calculate(budget))
+                .thenReturn(exceededResponse);
+
+        WalletUser ownerLink = memberOf(wallet, WalletRole.OWNER);
+        ownerLink.setUser(owner);
+        WalletUser memberLink = memberOf(wallet, WalletRole.MEMBER);
+
+        lenient().when(repositoryWalletUser.findByWalletId(walletId))
+                .thenReturn(List.of(ownerLink, memberLink));
+
+        budgetService.evaluateBudgetsForWallet(walletId);
+
+        verify(notificationService, never())
+                .sendBudgetGroupSuccess(any(), any(), any());
+        verify(notificationService, never())
+                .sendBudgetSuccess(any(), any());
+    }
+}

--- a/src/test/java/Diaz/Dev/BFlow/expenses/QuickExpenseServiceTest.java
+++ b/src/test/java/Diaz/Dev/BFlow/expenses/QuickExpenseServiceTest.java
@@ -1,0 +1,281 @@
+package Diaz.Dev.BFlow.expenses;
+
+import bflow.auth.entities.User;
+import bflow.auth.services.UserService;
+import bflow.budget.services.BudgetService;
+import bflow.category.entity.Category;
+import bflow.category.enums.CategoryType;
+import bflow.common.exception.ResourceNotFoundException;
+import bflow.expenses.DTO.ExpenseResponse;
+import bflow.expenses.DTO.QuickExpenseRequest;
+import bflow.expenses.RepositoryExpense;
+import bflow.expenses.entity.Expense;
+import bflow.expenses.services.QuickExpenseService;
+import bflow.merchant.MerchantDetectionService;
+import bflow.wallet.entities.Wallet;
+import bflow.wallet.entities.WalletUser;
+import bflow.wallet.enums.Currency;
+import bflow.wallet.enums.WalletRole;
+import bflow.wallet.repository.RepositoryWallet;
+import bflow.wallet.repository.RepositoryWalletUser;
+import bflow.wallet.service.ServiceWallet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link QuickExpenseService}, focused on the wallet
+ * balance fix: a quick expense must debit the wallet at creation
+ * time, using a locked wallet read, exactly like a normal expense
+ * does — otherwise a later edit or delete on the same record can
+ * mint balance that was never actually subtracted.
+ */
+@ExtendWith(MockitoExtension.class)
+class QuickExpenseServiceTest {
+
+    @Mock
+    private RepositoryExpense repositoryExpense;
+
+    @Mock
+    private RepositoryWallet repositoryWallet;
+
+    @Mock
+    private ServiceWallet serviceWallet;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private MerchantDetectionService merchantDetectionService;
+
+    @Mock
+    private RepositoryWalletUser walletUserRepository;
+
+    @Mock
+    private BudgetService budgetService;
+
+    @InjectMocks
+    private QuickExpenseService quickExpenseService;
+
+    private UUID userId;
+    private UUID walletId;
+    private User user;
+    private Wallet wallet;
+    private WalletUser walletUser;
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        walletId = UUID.randomUUID();
+
+        user = new User();
+        user.setId(userId);
+        user.setEmail("user@example.com");
+
+        wallet = new Wallet();
+        wallet.setId(walletId);
+        wallet.setName("Test Wallet");
+        wallet.setCurrency(Currency.USD);
+        wallet.setBalance(BigDecimal.valueOf(1000));
+        wallet.setCreatedAt(Instant.now());
+
+        walletUser = new WalletUser();
+        walletUser.setUser(user);
+        walletUser.setWallet(wallet);
+        walletUser.setRole(WalletRole.OWNER);
+
+        category = new Category();
+        category.setId(UUID.randomUUID());
+        category.setName("Food");
+        category.setType(CategoryType.EXPENSE);
+    }
+
+    private QuickExpenseRequest request(final BigDecimal amount) {
+        QuickExpenseRequest request = new QuickExpenseRequest();
+        request.setAmount(amount);
+        request.setDescription("Coffee");
+        return request;
+    }
+
+    @Test
+    void createQuickExpense_debitsWalletBalance_onCreation() {
+        when(walletUserRepository
+                .findFirstByUserIdAndRole(userId, WalletRole.OWNER))
+                .thenReturn(Optional.of(walletUser));
+        when(repositoryWallet.findByIdForUpdate(walletId))
+                .thenReturn(Optional.of(wallet));
+        when(merchantDetectionService.detectCategory(any()))
+                .thenReturn(category);
+        when(repositoryExpense.save(any(Expense.class)))
+                .thenAnswer(inv -> {
+                    Expense e = inv.getArgument(0);
+                    e.setId(UUID.randomUUID());
+                    e.setCreatedAt(Instant.now());
+                    return e;
+                });
+
+        quickExpenseService.createQuickExpense(
+                userId, request(BigDecimal.valueOf(50))
+        );
+
+        // This is the core regression check for both exploits: the
+        // fix must subtract the balance exactly once, on the same
+        // locked wallet instance, before the expense is persisted.
+        verify(serviceWallet, org.mockito.Mockito.times(1))
+                .subtractBalance(eq(wallet), eq(BigDecimal.valueOf(50)
+                        .setScale(2, java.math.RoundingMode.HALF_EVEN)));
+    }
+
+    @Test
+    void createQuickExpense_usesLockedWallet_notTheStaleWalletUserReference() {
+        Wallet lockedWallet = new Wallet();
+        lockedWallet.setId(walletId);
+        lockedWallet.setBalance(BigDecimal.valueOf(1000));
+        lockedWallet.setCurrency(Currency.USD);
+
+        when(walletUserRepository
+                .findFirstByUserIdAndRole(userId, WalletRole.OWNER))
+                .thenReturn(Optional.of(walletUser));
+        when(repositoryWallet.findByIdForUpdate(walletId))
+                .thenReturn(Optional.of(lockedWallet));
+        when(merchantDetectionService.detectCategory(any()))
+                .thenReturn(category);
+        when(repositoryExpense.save(any(Expense.class)))
+                .thenAnswer(inv -> {
+                    Expense e = inv.getArgument(0);
+                    e.setId(UUID.randomUUID());
+                    e.setCreatedAt(Instant.now());
+                    return e;
+                });
+
+        quickExpenseService.createQuickExpense(
+                userId, request(BigDecimal.TEN)
+        );
+
+        ArgumentCaptor<Expense> captor = ArgumentCaptor.forClass(Expense.class);
+        verify(repositoryExpense).save(captor.capture());
+
+        // The persisted expense must reference the locked wallet
+        // instance, not the possibly-stale one from WalletUser.
+        assertEquals(lockedWallet, captor.getValue().getWallet());
+        verify(serviceWallet).subtractBalance(eq(lockedWallet), any());
+    }
+
+    @Test
+    void createQuickExpense_insufficientBalance_neverPersistsExpense() {
+        when(walletUserRepository
+                .findFirstByUserIdAndRole(userId, WalletRole.OWNER))
+                .thenReturn(Optional.of(walletUser));
+        when(repositoryWallet.findByIdForUpdate(walletId))
+                .thenReturn(Optional.of(wallet));
+        when(merchantDetectionService.detectCategory(any()))
+                .thenReturn(category);
+
+        // Simulate ServiceWallet enforcing that balance can't go
+        // negative — this is the real guard the previous
+        // implementation completely bypassed.
+        org.mockito.Mockito.doThrow(new IllegalArgumentException(
+                        "Insufficient balance: " + wallet.getBalance()))
+                .when(serviceWallet)
+                .subtractBalance(eq(wallet), eq(BigDecimal.valueOf(5000)
+                        .setScale(2, java.math.RoundingMode.HALF_EVEN)));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                quickExpenseService.createQuickExpense(
+                        userId, request(BigDecimal.valueOf(5000))
+                )
+        );
+
+        // Exploit #1 regression guard: if the debit fails, no expense
+        // record should ever reach the database — otherwise you'd
+        // have an expense with no matching balance movement again,
+        // just via a different path (a failed-but-partially-applied
+        // quick expense).
+        verify(repositoryExpense, never()).save(any(Expense.class));
+        verify(budgetService, never())
+                .evaluateBudgetsForExpenseEvent(any(), any());
+    }
+
+    @Test
+    void createQuickExpense_deactivatedUser_isRejectedBeforeTouchingWallet() {
+        org.mockito.Mockito.doThrow(new RuntimeException("User is inactive"))
+                .when(userService).validateUserActive(userId);
+
+        assertThrows(RuntimeException.class, () ->
+                quickExpenseService.createQuickExpense(
+                        userId, request(BigDecimal.TEN)
+                )
+        );
+
+        verify(repositoryWallet, never()).findByIdForUpdate(any());
+        verify(serviceWallet, never()).subtractBalance(any(), any());
+    }
+
+    @Test
+    void createQuickExpense_missingWallet_throwsResourceNotFound() {
+        when(walletUserRepository
+                .findFirstByUserIdAndRole(userId, WalletRole.OWNER))
+                .thenReturn(Optional.of(walletUser));
+        when(repositoryWallet.findByIdForUpdate(walletId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () ->
+                quickExpenseService.createQuickExpense(
+                        userId, request(BigDecimal.TEN)
+                )
+        );
+
+        verify(serviceWallet, never()).subtractBalance(any(), any());
+        verify(repositoryExpense, never()).save(any());
+    }
+
+    @Test
+    void createQuickExpense_roundsAmountToTwoDecimals_beforeDebitAndSave() {
+        when(walletUserRepository
+                .findFirstByUserIdAndRole(userId, WalletRole.OWNER))
+                .thenReturn(Optional.of(walletUser));
+        when(repositoryWallet.findByIdForUpdate(walletId))
+                .thenReturn(Optional.of(wallet));
+        when(merchantDetectionService.detectCategory(any()))
+                .thenReturn(category);
+        when(repositoryExpense.save(any(Expense.class)))
+                .thenAnswer(inv -> {
+                    Expense e = inv.getArgument(0);
+                    e.setId(UUID.randomUUID());
+                    e.setCreatedAt(Instant.now());
+                    return e;
+                });
+
+        // Three decimals in, HALF_EVEN rounding to two decimals out —
+        // matches ServiceExpense's behavior so both entry points
+        // agree on wallet precision.
+        ExpenseResponse response = quickExpenseService.createQuickExpense(
+                userId, request(new BigDecimal("12.346"))
+        );
+
+        BigDecimal expected = new BigDecimal("12.35").setScale(
+                2, java.math.RoundingMode.HALF_EVEN);
+
+        assertEquals(0, expected.compareTo(response.getAmount()));
+        verify(serviceWallet).subtractBalance(eq(wallet), eq(expected));
+    }
+}

--- a/src/test/java/Diaz/Dev/BFlow/notifications/NotificationServiceTest.java
+++ b/src/test/java/Diaz/Dev/BFlow/notifications/NotificationServiceTest.java
@@ -1,0 +1,126 @@
+package Diaz.Dev.BFlow.notifications;
+
+import bflow.auth.entities.User;
+import bflow.auth.repository.RepositoryUser;
+import bflow.budget.DTO.BudgetResponse;
+import bflow.common.aws.service.EmailTemplateService;
+import bflow.common.aws.service.SesEmailService;
+import bflow.notifications.entity.Notification;
+import bflow.notifications.enums.NotificationType;
+import bflow.notifications.repository.NotificationRepository;
+import bflow.notifications.service.NotificationService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NotificationService#sendBudgetGroupSuccess},
+ * which fans a single "budget stayed on track" event out to every
+ * member of a shared wallet as both an in-app notification and a
+ * Thymeleaf-templated email.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private SesEmailService emailService;
+
+    @Mock
+    private RepositoryUser repositoryUser;
+
+    @Mock
+    private EmailTemplateService emailTemplateService;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(
+                notificationRepository,
+                emailService,
+                repositoryUser,
+                emailTemplateService
+        );
+
+        // Shared stub — not every test in this class triggers a
+        // save (the empty-member-list test doesn't), so it's
+        // lenient rather than strict to avoid a false-positive
+        // UnnecessaryStubbingException there.
+        lenient().when(notificationRepository.save(any(Notification.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private User user(final String email, final String name) {
+        User u = new User();
+        u.setId(UUID.randomUUID());
+        u.setEmail(email);
+        u.setName(name);
+        return u;
+    }
+
+    @Test
+    void sendBudgetGroupSuccess_notifiesAndEmailsEveryMember() {
+        User alice = user("alice@example.com", "Alice");
+        User bob = user("bob@example.com", "Bob");
+        BudgetResponse response = new BudgetResponse();
+
+        notificationService.sendBudgetGroupSuccess(
+                List.of(alice, bob), "Household", response);
+
+        ArgumentCaptor<Notification> notifCaptor =
+                ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository, times(2))
+                .save(notifCaptor.capture());
+
+        List<Notification> saved = notifCaptor.getAllValues();
+        assertEquals(2, saved.size());
+        assertEquals(NotificationType.BUDGET_GROUP_SUCCESS,
+                saved.get(0).getType());
+        assertEquals(alice.getId(), saved.get(0).getUserId());
+        assertEquals(bob.getId(), saved.get(1).getUserId());
+
+        // Each member gets their own Thymeleaf-templated email,
+        // addressed by name, not a single blast email.
+        verify(emailTemplateService).sendBudgetGroupSuccessEmail(
+                eq("alice@example.com"), eq("Alice"),
+                eq("Household"), eq(response));
+        verify(emailTemplateService).sendBudgetGroupSuccessEmail(
+                eq("bob@example.com"), eq("Bob"),
+                eq("Household"), eq(response));
+
+        // This flow must go through the templated path, never the
+        // legacy plain-text sendEmail used by the personal flow.
+        verify(emailService, never()).sendEmail(any(), any(), any());
+    }
+
+    @Test
+    void sendBudgetGroupSuccess_emptyMemberList_sendsNothing() {
+        BudgetResponse response = new BudgetResponse();
+
+        notificationService.sendBudgetGroupSuccess(
+                List.of(), "Household", response);
+
+        verify(notificationRepository, never()).save(any());
+        verify(emailTemplateService, never())
+                .sendBudgetGroupSuccessEmail(any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Overview

### Issue 1 — 503 on PATCH /api/v1/users/me/picture
`bflow-ecs-task-role` was missing the `s3:PutObject` permission on
`bflow-files-dev`. The script `infra/s3/05-configure-iam.sh` already
existed in the repo but had never been run against dev — it was still
marked `# Not tested yet`.

**Fix:** ran the script against `bflow-files-dev` / `bflow-ecs-task-role`,
verified with `06-verify.sh`, and removed the untested marker.

```bash
S3_BUCKET=bflow-files-dev \
ECS_TASK_ROLE_NAME=bflow-ecs-task-role \
./infra/s3/05-configure-iam.sh
```

### Issue 2 — display name reverts to Google's after any navigation
`PATCH /me` correctly persisted the new name, but `/api/v1/auth/sync`
(which runs on every screen) unconditionally overwrote it from the
Cognito/Google claim in `AuthSyncService.applyProfileClaims`.

**Fix:** introduced `NameSource` (mirroring the existing `PictureSource`
pattern used for avatars). `PATCH /me` now marks `nameSource = USER`;
`/auth/sync` only overwrites the name when `nameSource != USER`.

### Migration
`V27__add_name_source_to_users.sql` — defaults every existing row to
`GOOGLE`, since there's no retroactive way to tell whether a user's
current name was already manually customized. Only names set via
`PATCH /me` from this point forward are protected.

### Changes
- `enums/NameSource.java` — new enum (`GOOGLE`, `USER`)
- `entities/User.java` — new `nameSource` field, defaults to `GOOGLE`
- `services/UserService.java` — `updateProfile` sets `nameSource = USER` on manual name change
- `services/AuthSyncService.java` — `applyProfileClaims` guards the name overwrite the same way it already guards the picture overwrite
- `db/migration/V26__add_name_source_to_users.sql` — new column with backfill default
- `infra/s3/05-configure-iam.sh` — removed `Not tested yet` marker
